### PR TITLE
Potential fix for code scanning alert no. 53: Type confusion through parameter tampering

### DIFF
--- a/src/modules/tickers/tickers.controller.ts
+++ b/src/modules/tickers/tickers.controller.ts
@@ -53,13 +53,23 @@ export class TickersController {
   })
   @Get()
   getAll(
-    @Query('search') search: string,
+    @Query('search') search: string | string[],
     @Query('external') external: string,
     @Req() req: any,
   ) {
+    // Normalize `search` to a single string or undefined to avoid type confusion
+    let normalizedSearch: string | undefined;
+    if (typeof search === 'string') {
+      normalizedSearch = search;
+    } else if (Array.isArray(search)) {
+      normalizedSearch = search.find((v) => typeof v === 'string' && v.length > 0);
+    } else {
+      normalizedSearch = undefined;
+    }
+
     const isPro = req.user?.tier === 'pro' || req.user?.role === 'admin';
     const shouldSearchExternal = isPro && external === 'true';
-    return this.tickersService.searchTickers(search, shouldSearchExternal);
+    return this.tickersService.searchTickers(normalizedSearch, shouldSearchExternal);
   }
 
   @ApiOperation({

--- a/src/modules/tickers/tickers.service.ts
+++ b/src/modules/tickers/tickers.service.ts
@@ -365,12 +365,15 @@ export class TickersService {
     });
 
     // 2. External Search (Fallback/Supplement)
-    if (search.length >= 2 && includeExternal) {
+    const searchStr =
+      typeof search === 'string' ? search.trim() : '';
+
+    if (searchStr.length >= 2 && includeExternal) {
       try {
         const [finnhubResult, yahooResult, pendingRequests] =
           await Promise.allSettled([
-            this.finnhubService.searchSymbols(search),
-            this.yahooFinanceService.search(search),
+            this.finnhubService.searchSymbols(searchStr),
+            this.yahooFinanceService.search(searchStr),
             this.requestRepo.find({ where: { status: 'PENDING' } }), // Fetch pending requests
           ]);
 


### PR DESCRIPTION
Potential fix for [https://github.com/404-Profit-Not-Found/neural-ticker-core/security/code-scanning/53](https://github.com/404-Profit-Not-Found/neural-ticker-core/security/code-scanning/53)

In general terms, the fix is to validate and normalize the `search` parameter to a proper string before using it, rejecting or sanitizing any non-string (including arrays). This prevents type confusion arising from request parameter tampering.

The best targeted fix is to enforce the string type at the boundary between controller and service. We can do this by (a) adjusting the controller’s `getAll` method to defensively normalize `search` (handling the case where `@Query` gives an array, number, etc.), and (b) hardening the service to guard against non-string `search` values before using `search.length` and passing it to external services. Concretely:

- In `TickersController.getAll` (around line 56), change the type of `search` from `string` to `string | string[]` (the realistic runtime possibilities) and then compute a safe `normalizedSearch`:
  - If `search` is an array, pick the first non-empty string element, or join elements, or simply reject; the safest is to pick the first string value or set to `undefined`.
  - If `search` is not a string, coerce to `undefined`.
  - Pass `normalizedSearch` (which is `string | undefined`) to `this.tickersService.searchTickers`.

- In `TickersService.searchTickers` (lines 277–280 and the condition at line 368), widen the parameter type to `string | undefined` (it already matches that, but we’ll explicitly guard at runtime) and add an early normalization/validation:
  - If `typeof search !== 'string'`, either return `mappedDbResults`/local-only results or treat it as `undefined`.
  - Use a local `const searchStr = search.trim();` and then reference `searchStr` in `if (searchStr.length >= 2 && includeExternal)` and in the calls to `finnhubService` and `yahooFinanceService`.
  - If `searchStr` is empty, skip external search altogether.

These changes maintain existing functionality (search still accepts and uses a string) while ensuring that any array or other unexpected type cannot trigger confusing behavior or be passed on to external services.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
