### PR TITLE
Potential fix for code scanning alert no. 27: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -162,16 +162,24 @@ export function ProfilePage() {
                                 <div className="w-full h-full rounded-full overflow-hidden bg-background">
                                     {(() => {
                                         const url = avatarUrl || user?.avatar_url;
-                                        const isSafeUrl = (u: string) => {
+                                        const getSafeUrl = (u: string): string | null => {
                                             try {
                                                 const parsed = new URL(u);
-                                                return ['http:', 'https:'].includes(parsed.protocol);
+                                                if (
+                                                    ['http:', 'https:'].includes(parsed.protocol) &&
+                                                    parsed.hostname
+                                                ) {
+                                                    // Use the canonical href to avoid odd relative/invalid forms
+                                                    return parsed.href;
+                                                }
+                                                return null;
                                             } catch {
-                                                return false;
+                                                return null;
                                             }
                                         };
-                                        return url && isSafeUrl(url) ? (
-                                            <img src={url} alt="Profile" className="w-full h-full object-cover" />
+                                        const safeUrl = url ? getSafeUrl(url) : null;
+                                        return safeUrl ? (
+                                            <img src={safeUrl} alt="Profile" className="w-full h-full object-cover" />
                                         ) : (
                                             <div className="w-full h-full flex items-center justify-center bg-muted text-muted-foreground text-lg font-medium">
                                                 {(user?.nickname || user?.email || '??').slice(0, 2).toUpperCase()}


### PR DESCRIPTION
Potential fix for [https://github.com/404-Profit-Not-Found/neural-ticker-core/security/code-scanning/27](https://github.com/404-Profit-Not-Found/neural-ticker-core/security/code-scanning/27)

In general terms, the fix is to ensure that the user-supplied string used as `img.src` is robustly validated and constrained, so that only clearly safe, expected URLs are allowed. This means tightening the `isSafeUrl` function rather than using the raw value directly, and possibly restricting URLs further (e.g., only allowing `https:` or even limiting to a particular domain or image CDN, if appropriate for the application). The goal is to avoid any situation where browser quirks or non-standard schemes could turn a text value coming from the DOM into something that executes script or behaves unexpectedly.

The single best fix here, without changing visible functionality, is to (a) keep `isSafeUrl` but make it slightly stricter and more explicit, and (b) derive a sanitized URL string to pass into the `<img src={...}>`. Since we cannot see the rest of the codebase and we should not assume additional app-specific constraints, we can:  
- Update `isSafeUrl` to only accept `http:` and `https:` (already done) but also to ensure there is a non-empty hostname, rejecting URLs like `http:foo` or paths that parse oddly.  
- Use a sanitized version of `url` obtained from `new URL(url)` so that if the input had odd characters or whitespace, we consistently pass a normalized, canonical string to the DOM.  
These changes happen in `frontend/src/pages/ProfilePage.tsx`, in the inline IIFE that renders the avatar (around lines 164–175). No new external packages are required; we use the built-in `URL` class. Functionality remains the same for legitimate URLs (they still work), but malformed or suspicious inputs are rejected and cause the placeholder initials avatar to be displayed instead.

Concretely:
- Modify `isSafeUrl` so that, after parsing, it checks both `protocol` and that `hostname` is non-empty.
- When rendering `<img>`, compute `const safeUrl = isSafeUrl(url);` where `isSafeUrl` returns a normalized URL string or `null`/`undefined` rather than just a boolean, and then use `safeUrl` as the `src`. This ensures that any unsafe value is never passed to the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
