### PR TITLE
Potential fix for code scanning alert no. 15: Use of externally-controlled format string

### DIFF
--- a/src/modules/tickers/ticker-detail.controller.ts
+++ b/src/modules/tickers/ticker-detail.controller.ts
@@ -40,7 +40,7 @@ export class TickerDetailController {
     try {
       snapshot = await this.marketDataService.getSnapshot(symbol);
     } catch (e) {
-      console.error(`Error getting snapshot for ${symbol}:`, e);
+      console.error('Error getting snapshot for %s:', symbol, e);
       throw e;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/404-Profit-Not-Found/neural-ticker-core/security/code-scanning/15](https://github.com/404-Profit-Not-Found/neural-ticker-core/security/code-scanning/15)

In general, to fix externally-controlled format string issues with `console.log`/`console.error`/`util.format`, ensure that the format string is a constant and pass untrusted data as subsequent arguments, or sanitize/remove any `%` sequences in untrusted data before interpolating them into the format string.

For this specific case, the best low-impact fix is to stop embedding `symbol` directly into the first argument to `console.error`. Instead, use a constant format string and pass both `symbol` and `e` as separate arguments. That means changing line 43 from:

```ts
console.error(`Error getting snapshot for ${symbol}:`, e);
```

to something like:

```ts
console.error('Error getting snapshot for %s:', symbol, e);
```

This keeps the log content effectively the same (static prefix, the symbol value, then the error object), but the first argument is now a static format string, and the user-provided `symbol` is no longer part of it. No new imports, helpers, or additional definitions are required; this is a one-line change inside `src/modules/tickers/ticker-detail.controller.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
