### PR TITLE
Store notification preferences in DB for cross-device sync

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -19,8 +19,8 @@ self.addEventListener('push', (event) => {
 
   const options = {
     body: payload.body || '',
-    icon: payload.icon || '/logo-sso.png',
-    badge: '/logo-sso.png',
+    icon: payload.icon || '/favicon.svg',
+    badge: '/favicon.svg',
     data: payload.data || {},
     vibrate: [100, 50, 100],
     tag: payload.data?.alertType

--- a/frontend/src/components/dashboard/TickerCarousel.tsx
+++ b/frontend/src/components/dashboard/TickerCarousel.tsx
@@ -58,6 +58,7 @@ export function TickerCarousel({ data, isLoading }: TickerCarouselProps) {
                             fiftyTwoWeekLow={item.fiftyTwoWeekLow ?? undefined}
                             fiftyTwoWeekHigh={item.fiftyTwoWeekHigh ?? undefined}
                             marketStatus={status}
+                            currency={item.currency}
                         />
                     );
                 })}

--- a/frontend/src/components/portfolio/PortfolioTable.tsx
+++ b/frontend/src/components/portfolio/PortfolioTable.tsx
@@ -8,6 +8,7 @@ import { calculateLiveUpside } from '../../lib/rating-utils';
 import { VerdictBadge } from "../ticker/VerdictBadge";
 import { FiftyTwoWeekRange } from '../dashboard/FiftyTwoWeekRange';
 import { Sparkline } from '../ui/Sparkline';
+import { useCurrency } from '../../context/CurrencyContext';
 
 export interface Position {
     id: string;
@@ -79,6 +80,7 @@ const formatPct = (val: number) =>
 
 export function PortfolioTable({ positions, onDelete, onEdit, loading }: PortfolioTableProps) {
     const navigate = useNavigate();
+    const { displayCurrency } = useCurrency();
     const columnHelper = createColumnHelper<Position>();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -157,7 +159,7 @@ export function PortfolioTable({ positions, onDelete, onEdit, loading }: Portfol
                 // Use converted (Display) values for Value & Return columns
                 const val = row.current_value;
                 const gainLoss = row.gain_loss;
-                const currency = row.currency || 'USD';
+                const currency = row.currency || displayCurrency || 'USD';
                 
                 const pct = info.getValue();
                 const isProfit = gainLoss >= 0;
@@ -209,7 +211,7 @@ export function PortfolioTable({ positions, onDelete, onEdit, loading }: Portfol
             cell: (info) => {
                 const row = info.row.original;
                 const price = info.getValue();
-                const currency = row.currency || 'USD';
+                const currency = row.currency || displayCurrency || 'USD';
                 const change = row.change_percent || 0;
                 const isPositive = change >= 0;
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -14,6 +14,7 @@ interface User {
     credits_balance?: number;
     avatar_url: string;
     has_onboarded?: boolean;
+    preferences?: Record<string, any>;
 }
 
 interface AuthContextType {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,6 +2,16 @@ import React, { createContext, useContext, useState, useEffect, useRef, useCallb
 import { httpClient } from '../lib/api';
 import { queryClient, persister } from '../lib/queryClient';
 
+interface NotificationPreferences {
+    push_enabled?: boolean;
+    email_enabled?: boolean;
+}
+
+interface UserPreferences {
+    notifications?: NotificationPreferences;
+    [key: string]: unknown;
+}
+
 interface User {
     id: string;
     email: string;
@@ -14,7 +24,7 @@ interface User {
     credits_balance?: number;
     avatar_url: string;
     has_onboarded?: boolean;
-    preferences?: Record<string, any>;
+    preferences?: UserPreferences;
 }
 
 interface AuthContextType {

--- a/frontend/src/hooks/useTicker.ts
+++ b/frontend/src/hooks/useTicker.ts
@@ -173,7 +173,9 @@ export function useToggleCommentLike() {
             queryClient.setQueryData(tickerKeys.social(symbol), (old: any) => {
                 if (!old) return old;
                 const delta = wasLiked ? -1 : 1;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const updateComments = (comments: any[]) =>
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     comments.map((c: any) => ({
                         ...c,
                         like_count: c.id === commentId ? Math.max(0, (c.like_count || 0) + delta) : c.like_count,

--- a/frontend/src/hooks/useTicker.ts
+++ b/frontend/src/hooks/useTicker.ts
@@ -153,7 +153,48 @@ export function useToggleCommentLike() {
             const res = await api.post(`/social/comments/${commentId}/like`);
             return res.data as { liked: boolean; likeCount: number };
         },
-        onSuccess: (_, variables) => {
+        onMutate: async ({ commentId, symbol }) => {
+            // Cancel outgoing refetches so they don't overwrite our optimistic update
+            await queryClient.cancelQueries({ queryKey: tickerKeys.social(symbol) });
+            await queryClient.cancelQueries({ queryKey: ['social', 'my-likes', symbol] });
+
+            // Snapshot previous values for rollback
+            const prevSocial = queryClient.getQueryData(tickerKeys.social(symbol));
+            const prevLikes = queryClient.getQueryData<string[]>(['social', 'my-likes', symbol]);
+
+            // Optimistically toggle the liked IDs
+            const wasLiked = prevLikes?.includes(commentId) ?? false;
+            queryClient.setQueryData<string[]>(['social', 'my-likes', symbol], (old = []) =>
+                wasLiked ? old.filter((id) => id !== commentId) : [...old, commentId],
+            );
+
+            // Optimistically update like_count on the comment
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            queryClient.setQueryData(tickerKeys.social(symbol), (old: any) => {
+                if (!old) return old;
+                const delta = wasLiked ? -1 : 1;
+                const updateComments = (comments: any[]) =>
+                    comments.map((c: any) => ({
+                        ...c,
+                        like_count: c.id === commentId ? Math.max(0, (c.like_count || 0) + delta) : c.like_count,
+                        replies: c.replies ? updateComments(c.replies) : c.replies,
+                    }));
+                return { ...old, comments: updateComments(old.comments || []) };
+            });
+
+            return { prevSocial, prevLikes };
+        },
+        onError: (_err, variables, context) => {
+            // Rollback on error
+            if (context?.prevSocial) {
+                queryClient.setQueryData(tickerKeys.social(variables.symbol), context.prevSocial);
+            }
+            if (context?.prevLikes) {
+                queryClient.setQueryData(['social', 'my-likes', variables.symbol], context.prevLikes);
+            }
+        },
+        onSettled: (_, _err, variables) => {
+            // Refetch to ensure server state is in sync
             queryClient.invalidateQueries({ queryKey: tickerKeys.social(variables.symbol) });
             queryClient.invalidateQueries({ queryKey: ['social', 'my-likes', variables.symbol] });
         },

--- a/frontend/src/hooks/useTicker.ts
+++ b/frontend/src/hooks/useTicker.ts
@@ -174,7 +174,7 @@ export function useToggleCommentLike() {
                 if (!old) return old;
                 const delta = wasLiked ? -1 : 1;
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const updateComments = (comments: any[]) =>
+                const updateComments = (comments: any[]): any[] =>
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     comments.map((c: any) => ({
                         ...c,

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -40,6 +40,11 @@ export function ProfilePage() {
     const [isEditingAvatar, setIsEditingAvatar] = useState(false);
     const { isSupported: pushSupported, isSubscribed: pushSubscribed, isLoading: pushLoading, subscribe: pushSubscribe, unsubscribe: pushUnsubscribe } = useWebPush();
 
+    // DB-backed notification preferences (cross-device)
+    const [pushEnabled, setPushEnabled] = useState(true);
+    const [emailEnabled, setEmailEnabled] = useState(false);
+    const [isSavingNotifPrefs, setIsSavingNotifPrefs] = useState(false);
+
     // Live Preview Effect
     useEffect(() => {
         let previewTheme = theme;
@@ -64,6 +69,10 @@ export function ProfilePage() {
             setOriginalNickname(nick);
             setAvatarUrl(user.avatar_url || '');
             setTheme(user.theme || 'g100');
+            // Hydrate notification preferences from DB
+            const notifPrefs = user.preferences?.notifications;
+            setPushEnabled(notifPrefs?.push_enabled ?? true);
+            setEmailEnabled(notifPrefs?.email_enabled ?? false);
         }
     }, [user]);
 
@@ -126,6 +135,49 @@ export function ProfilePage() {
         setTheme(newTheme);
         saveChanges(nickname, avatarUrl, newTheme);
     };
+
+    // Save notification preferences to DB (cross-device)
+    const saveNotificationPreference = useCallback(async (key: 'push_enabled' | 'email_enabled', value: boolean) => {
+        setIsSavingNotifPrefs(true);
+        try {
+            await api.post('/users/me/preferences', {
+                notifications: {
+                    ...(user?.preferences?.notifications || {}),
+                    [key]: value,
+                },
+            });
+            await refreshSession();
+        } catch (error) {
+            console.error('Failed to save notification preference', error);
+        } finally {
+            setIsSavingNotifPrefs(false);
+        }
+    }, [user?.preferences?.notifications, refreshSession]);
+
+    // Toggle push: save to DB + subscribe/unsubscribe browser push
+    const handlePushToggle = useCallback(async () => {
+        const newValue = !pushEnabled;
+        setPushEnabled(newValue); // optimistic
+
+        if (newValue) {
+            const ok = await pushSubscribe();
+            if (!ok) {
+                setPushEnabled(false); // revert if browser denied
+                return;
+            }
+        } else {
+            await pushUnsubscribe();
+        }
+
+        await saveNotificationPreference('push_enabled', newValue);
+    }, [pushEnabled, pushSubscribe, pushUnsubscribe, saveNotificationPreference]);
+
+    // Toggle email: save to DB only
+    const handleEmailToggle = useCallback(async () => {
+        const newValue = !emailEnabled;
+        setEmailEnabled(newValue); // optimistic
+        await saveNotificationPreference('email_enabled', newValue);
+    }, [emailEnabled, saveNotificationPreference]);
 
     // Get tier badge (exact match to Admin Console UserAdminCard)
     const getTierBadge = (tier: string | undefined) => {
@@ -367,42 +419,75 @@ export function ProfilePage() {
                 </div>
 
                 {/* NOTIFICATIONS SECTION */}
-                {pushSupported && (
-                    <div className="space-y-3">
-                        <h2 className="text-xs font-medium uppercase tracking-widest text-muted-foreground px-1">Notifications</h2>
+                <div className="space-y-3">
+                    <h2 className="text-xs font-medium uppercase tracking-widest text-muted-foreground px-1">Notifications</h2>
 
-                        <div className="bg-card border border-border/40 rounded-xl p-4">
-                            <div className="flex items-center gap-3">
+                    <div className="bg-card border border-border/40 rounded-xl overflow-hidden">
+                        {/* Push Notifications Toggle */}
+                        {pushSupported && (
+                            <div className="p-4 flex items-center gap-3">
                                 <div className="w-10 h-10 rounded-xl bg-muted/50 flex items-center justify-center">
                                     <Bell size={18} className="text-muted-foreground" />
                                 </div>
                                 <div className="flex-1">
                                     <div className="text-sm font-medium">Push Notifications</div>
                                     <div className="text-xs text-muted-foreground">
-                                        {pushSubscribed
+                                        {pushEnabled && pushSubscribed
                                             ? 'Receive alerts even when the tab is closed'
                                             : 'Enable to get price alerts in your browser'}
                                     </div>
                                 </div>
                                 <button
-                                    onClick={() => pushSubscribed ? pushUnsubscribe() : pushSubscribe()}
-                                    disabled={pushLoading}
+                                    onClick={handlePushToggle}
+                                    disabled={pushLoading || isSavingNotifPrefs}
                                     className={cn(
                                         "relative w-11 h-6 rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50",
-                                        pushSubscribed ? "bg-emerald-500" : "bg-muted"
+                                        pushEnabled ? "bg-emerald-500" : "bg-muted"
                                     )}
                                 >
                                     <span
                                         className={cn(
                                             "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200",
-                                            pushSubscribed && "translate-x-5"
+                                            pushEnabled && "translate-x-5"
                                         )}
                                     />
                                 </button>
                             </div>
+                        )}
+
+                        {pushSupported && <div className="h-px bg-border/40" />}
+
+                        {/* Email Notifications Toggle */}
+                        <div className="p-4 flex items-center gap-3">
+                            <div className="w-10 h-10 rounded-xl bg-muted/50 flex items-center justify-center">
+                                <Mail size={18} className="text-muted-foreground" />
+                            </div>
+                            <div className="flex-1">
+                                <div className="text-sm font-medium">Email Notifications</div>
+                                <div className="text-xs text-muted-foreground">
+                                    {emailEnabled
+                                        ? 'Receive alerts via email'
+                                        : 'Enable to get notifications by email'}
+                                </div>
+                            </div>
+                            <button
+                                onClick={handleEmailToggle}
+                                disabled={isSavingNotifPrefs}
+                                className={cn(
+                                    "relative w-11 h-6 rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50",
+                                    emailEnabled ? "bg-emerald-500" : "bg-muted"
+                                )}
+                            >
+                                <span
+                                    className={cn(
+                                        "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200",
+                                        emailEnabled && "translate-x-5"
+                                    )}
+                                />
+                            </button>
                         </div>
                     </div>
-                )}
+                </div>
 
                 {/* VERSION FOOTER */}
                 <div className="pt-8 text-center">

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -245,6 +245,20 @@ export class UsersService {
     return this.userRepo.findOne({ where: { id } });
   }
 
+  /**
+   * Get notification channel preferences for a user, with defaults.
+   */
+  async getNotificationPreferences(
+    userId: string,
+  ): Promise<{ push_enabled: boolean; email_enabled: boolean }> {
+    const user = await this.findById(userId);
+    const prefs = user?.preferences?.notifications;
+    return {
+      push_enabled: prefs?.push_enabled ?? true,
+      email_enabled: prefs?.email_enabled ?? false,
+    };
+  }
+
   async getProfile(id: string): Promise<User | null> {
     return this.userRepo.findOne({
       where: { id },

--- a/src/modules/web-push/web-push.module.ts
+++ b/src/modules/web-push/web-push.module.ts
@@ -1,11 +1,15 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PushSubscriptionEntity } from './entities/push-subscription.entity';
 import { WebPushService } from './web-push.service';
 import { WebPushController } from './web-push.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PushSubscriptionEntity])],
+  imports: [
+    TypeOrmModule.forFeature([PushSubscriptionEntity]),
+    forwardRef(() => UsersModule),
+  ],
   controllers: [WebPushController],
   providers: [WebPushService],
   exports: [WebPushService],

--- a/src/modules/web-push/web-push.service.spec.ts
+++ b/src/modules/web-push/web-push.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { WebPushService } from './web-push.service';
 import { PushSubscriptionEntity } from './entities/push-subscription.entity';
+import { UsersService } from '../users/users.service';
 
 // Mock web-push module
 jest.mock('web-push', () => ({
@@ -23,6 +24,13 @@ describe('WebPushService', () => {
     delete: jest.fn(),
   };
 
+  const mockUsersService = {
+    getNotificationPreferences: jest.fn().mockResolvedValue({
+      push_enabled: true,
+      email_enabled: false,
+    }),
+  };
+
   const buildModule = async (config: Record<string, string>) => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -39,6 +47,10 @@ describe('WebPushService', () => {
                 config[key] ?? defaultValue,
             ),
           },
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
         },
       ],
     }).compile();
@@ -283,6 +295,27 @@ describe('WebPushService', () => {
       await service.sendToUser('user1', { title: 'Test', body: 'Missing' });
 
       expect(mockSubRepo.delete).toHaveBeenCalledWith({ id: '2' });
+    });
+
+    it('should not send when push_enabled is false in user preferences', async () => {
+      mockUsersService.getNotificationPreferences.mockResolvedValueOnce({
+        push_enabled: false,
+        email_enabled: false,
+      });
+      mockSubRepo.find.mockResolvedValue([
+        {
+          id: '1',
+          user_id: 'user1',
+          endpoint: 'https://push.example.com',
+          p256dh: 'p1',
+          auth: 'a1',
+        },
+      ]);
+
+      await service.sendToUser('user1', { title: 'Test', body: 'Disabled' });
+
+      expect(mockSubRepo.find).not.toHaveBeenCalled();
+      expect(webpush.sendNotification).not.toHaveBeenCalled();
     });
 
     it('should not send when VAPID is not configured', async () => {

--- a/src/modules/web-push/web-push.service.ts
+++ b/src/modules/web-push/web-push.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Inject, Logger, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import * as webpush from 'web-push';
 import { PushSubscriptionEntity } from './entities/push-subscription.entity';
+import { UsersService } from '../users/users.service';
 
 interface PushPayload {
   title: string;
@@ -21,6 +22,8 @@ export class WebPushService {
     @InjectRepository(PushSubscriptionEntity)
     private readonly subRepo: Repository<PushSubscriptionEntity>,
     private readonly configService: ConfigService,
+    @Inject(forwardRef(() => UsersService))
+    private readonly usersService: UsersService,
   ) {
     const vapidPublic = this.configService.get<string>('VAPID_PUBLIC_KEY');
     const vapidPrivate = this.configService.get<string>('VAPID_PRIVATE_KEY');
@@ -85,6 +88,16 @@ export class WebPushService {
    */
   async sendToUser(userId: string, payload: PushPayload): Promise<void> {
     if (!this.isConfigured) return;
+
+    // Check user's notification preferences
+    const prefs =
+      await this.usersService.getNotificationPreferences(userId);
+    if (!prefs.push_enabled) {
+      this.logger.debug(
+        `Push disabled for user ${userId}, skipping`,
+      );
+      return;
+    }
 
     const subscriptions = await this.subRepo.find({
       where: { user_id: userId },

--- a/src/modules/web-push/web-push.service.ts
+++ b/src/modules/web-push/web-push.service.ts
@@ -90,12 +90,9 @@ export class WebPushService {
     if (!this.isConfigured) return;
 
     // Check user's notification preferences
-    const prefs =
-      await this.usersService.getNotificationPreferences(userId);
+    const prefs = await this.usersService.getNotificationPreferences(userId);
     if (!prefs.push_enabled) {
-      this.logger.debug(
-        `Push disabled for user ${userId}, skipping`,
-      );
+      this.logger.debug(`Push disabled for user ${userId}, skipping`);
       return;
     }
 


### PR DESCRIPTION
Persist push_enabled and email_enabled in the user.preferences JSONB column so notification channel settings follow the user across devices. Backend gates web push delivery on the push_enabled preference, and the ProfilePage now syncs both toggles to the database with optimistic UI.