### PR TITLE
Cron fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 permissions:
   contents: read
 
-
+# Cancel obsolete in-flight runs for the same branch/PR so a fast `git push`
+# doesn't burn CI minutes on stale commits.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -27,8 +31,9 @@ jobs:
     needs: secrets-scan
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [22.x]
+        node-version: [20.x, 22.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
@@ -53,7 +58,11 @@ jobs:
   test:
     needs: secrets-scan
     runs-on: ubuntu-latest
+    # fail-fast:false so a Node 20 failure doesn't cancel the Node 22 leg
+    # mid-`docker pull` — that's what produced the confusing
+    # "Error: The operation was canceled." messages on the surviving leg.
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x, 22.x]
     services:
@@ -82,12 +91,16 @@ jobs:
     - name: Run Unit Tests with Coverage
       run: npm run test -- --coverage --coverageThreshold='{"global":{"branches":50,"functions":45,"lines":50,"statements":50}}'
       env:
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
-          DB_USERNAME: ${{ secrets.DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DB_DATABASE: ${{ secrets.DB_DATABASE }}
-          DB_SYNCHRONIZE: ${{ secrets.DB_SYNCHRONIZE }}
+          # DB env is hardcoded to match the `postgres` service container above.
+          # IMPORTANT: do NOT use ${{ secrets.DB_HOST }} here — combined with
+          # DB_SYNCHRONIZE=true (TypeORM auto-schema-sync) it would rewrite
+          # the schema of whatever DB the secret points to, including prod.
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: neural
+          DB_PASSWORD: password
+          DB_DATABASE: neural_db
+          DB_SYNCHRONIZE: 'true'
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -117,6 +130,7 @@ jobs:
     needs: secrets-scan
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x, 22.x]
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ ENV PORT=8080
 
 WORKDIR /app
 
+# Install curl — required by stocktwits.service.ts execFileSync fallback when
+# Cloudflare blocks Axios (403). Alpine ships without curl by default, so
+# without this the fallback silently fails with ENOENT in prod.
+RUN apk add --no-cache curl
+
 # Copy backend package files
 COPY package*.json ./
 

--- a/src/modules/jobs/jobs.service.spec.ts
+++ b/src/modules/jobs/jobs.service.spec.ts
@@ -29,6 +29,7 @@ describe('JobsService', () => {
     getHistory: jest.fn().mockResolvedValue([]),
     syncTickerHistory: jest.fn().mockResolvedValue(undefined),
     dedupeAnalystRatings: jest.fn().mockResolvedValue({ removed: 0 }),
+    pickStaleSnapshotTickers: jest.fn(),
   };
 
   const mockResearchService = {
@@ -48,10 +49,12 @@ describe('JobsService', () => {
 
   const mockMarketStatusService = {
     getAllMarketsStatus: jest.fn().mockResolvedValue({
-      us: { isOpen: true },
-      eu: { isOpen: true },
+      us: { isOpen: true, session: 'regular' },
+      eu: { isOpen: true, session: 'regular' },
     }),
-    getMarketStatus: jest.fn().mockResolvedValue({ isOpen: true }),
+    getMarketStatus: jest
+      .fn()
+      .mockResolvedValue({ isOpen: true, session: 'regular' }),
   };
 
   beforeEach(async () => {
@@ -133,6 +136,121 @@ describe('JobsService', () => {
       mockTickersService.getAllTickers.mockResolvedValue(tickers);
       await service.syncDailyCandles();
       expect(mockMarketDataService.getSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncSnapshots (batched)', () => {
+    let sleepSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      sleepSpy = jest
+        .spyOn(global, 'setTimeout')
+        // Resolve immediately to keep the test fast
+        .mockImplementation((callback: any) => {
+          callback();
+          return {} as NodeJS.Timeout;
+        });
+    });
+
+    afterEach(() => {
+      sleepSpy.mockRestore();
+    });
+
+    it('returns skipped:true when all markets are closed', async () => {
+      mockMarketStatusService.getAllMarketsStatus.mockResolvedValueOnce({
+        us: { isOpen: false, session: 'closed' },
+        eu: { isOpen: false, session: 'closed' },
+      });
+
+      const result = await service.syncSnapshots();
+
+      expect(result).toMatchObject({ skipped: true });
+      expect(
+        mockMarketDataService.pickStaleSnapshotTickers,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('asks market-data for the stale-first batch and syncs only those', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'TSLA' },
+        { symbol: 'MSFT' },
+      ]);
+      // Picker returns just two of the three — the batch limit in effect.
+      mockMarketDataService.pickStaleSnapshotTickers.mockResolvedValue([
+        'MSFT',
+        'AAPL',
+      ]);
+      mockMarketDataService.getSnapshot.mockResolvedValue({});
+
+      const result = await service.syncSnapshots();
+
+      expect(
+        mockMarketDataService.pickStaleSnapshotTickers,
+      ).toHaveBeenCalledWith(
+        ['AAPL', 'TSLA', 'MSFT'],
+        JobsService.SNAPSHOTS_BATCH_SIZE,
+      );
+      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledTimes(2);
+      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledWith('MSFT');
+      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledWith('AAPL');
+      expect(mockMarketDataService.getSnapshot).not.toHaveBeenCalledWith(
+        'TSLA',
+      );
+      expect(result).toMatchObject({
+        success: 2,
+        failed: 0,
+        batchSize: 2,
+        skipped: false,
+      });
+    });
+
+    it('skips a batch ticker whose own market is closed without failing the batch', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL', exchange: 'US' },
+        { symbol: 'SAP', exchange: 'EU' },
+      ]);
+      mockMarketDataService.pickStaleSnapshotTickers.mockResolvedValue([
+        'AAPL',
+        'SAP',
+      ]);
+      mockMarketStatusService.getMarketStatus
+        .mockResolvedValueOnce({ isOpen: true, session: 'regular' })
+        .mockResolvedValueOnce({ isOpen: false, session: 'closed' });
+      mockMarketDataService.getSnapshot.mockResolvedValue({});
+
+      const result = await service.syncSnapshots();
+
+      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledWith('AAPL');
+      expect(result).toMatchObject({
+        success: 1,
+        failed: 0,
+        skippedMarketClosed: 1,
+        batchSize: 2,
+      });
+    });
+
+    it('counts per-ticker errors without aborting the rest of the batch', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'BAD' },
+      ]);
+      mockMarketDataService.pickStaleSnapshotTickers.mockResolvedValue([
+        'AAPL',
+        'BAD',
+      ]);
+      mockMarketDataService.getSnapshot
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('finnhub 500'));
+
+      const result = await service.syncSnapshots();
+
+      expect(result).toMatchObject({
+        success: 1,
+        failed: 1,
+        batchSize: 2,
+      });
     });
   });
 

--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -177,7 +177,14 @@ export class JobsService {
   }
 
   /**
-   * Light sync - only fetches current price snapshots for all tickers.
+   * Batch size for the snapshot sync — sized so a single cron run finishes
+   * well inside the Cloud Run 5-min request timeout. The every-5-min cron
+   * rotates through all tickers across multiple runs via DB-driven staleness.
+   */
+  static readonly SNAPSHOTS_BATCH_SIZE = 25;
+
+  /**
+   * Light sync - fetches a batch of the most-stale price snapshots.
    * Much faster than syncDailyCandles since it skips history.
    * Syncs tickers only when their respective market is open.
    */
@@ -200,22 +207,38 @@ export class JobsService {
       }
     }
 
-    this.logger.log('Starting light snapshot sync (prices only)...');
+    this.logger.log('Starting light snapshot sync batch (prices only)...');
     try {
-      const tickers = await this.tickersService.getAllTickers();
-      this.logger.log(`Found ${tickers.length} tickers total.`);
+      const allTickers = await this.tickersService.getAllTickers();
+      const candidates = allTickers.filter(
+        (t): t is typeof t & { symbol: string } => !!t.symbol,
+      );
+      this.logger.log(`Found ${candidates.length} candidate tickers.`);
+
+      // Pick the N most-stale tickers (oldest MAX(ohlcv.ts) first, NULLs first).
+      const batchSize = JobsService.SNAPSHOTS_BATCH_SIZE;
+      const staleSymbols =
+        await this.marketDataService.pickStaleSnapshotTickers(
+          candidates.map((t) => t.symbol),
+          batchSize,
+        );
+      const exchangeBySymbol = new Map(
+        candidates.map((t) => [t.symbol, (t as any).exchange || 'US']),
+      );
+
+      this.logger.log(
+        `Batch tickers (${staleSymbols.length}/${candidates.length}): ${staleSymbols.join(', ')}`,
+      );
 
       let success = 0;
       let failed = 0;
       let skippedMarketClosed = 0;
 
-      for (const ticker of tickers) {
-        if (!ticker.symbol) continue;
-
+      for (const symbol of staleSymbols) {
         // Check if this ticker's market is open
-        const exchange = (ticker as any).exchange || 'US';
+        const exchange = exchangeBySymbol.get(symbol) || 'US';
         const status = await this.marketStatusService.getMarketStatus(
-          ticker.symbol,
+          symbol,
           exchange,
         );
 
@@ -226,22 +249,26 @@ export class JobsService {
 
         try {
           // getSnapshot already uses Finnhub with Yahoo fallback internally
-          await this.marketDataService.getSnapshot(ticker.symbol);
+          await this.marketDataService.getSnapshot(symbol);
           success++;
         } catch (err: any) {
           failed++;
-          this.logger.warn(
-            `Snapshot failed for ${ticker.symbol}: ${err.message}`,
-          );
+          this.logger.warn(`Snapshot failed for ${symbol}: ${err.message}`);
         }
         // Shorter delay since it's just snapshots (500ms)
         await new Promise((r) => setTimeout(r, 500));
       }
 
       this.logger.log(
-        `Snapshot sync complete. Success: ${success}, Failed: ${failed}, Skipped (market closed): ${skippedMarketClosed}`,
+        `Snapshot batch complete. Success: ${success}, Failed: ${failed}, Skipped (market closed): ${skippedMarketClosed}, Batch size: ${staleSymbols.length}`,
       );
-      return { success, failed, skipped: false };
+      return {
+        success,
+        failed,
+        skipped: false,
+        batchSize: staleSymbols.length,
+        skippedMarketClosed,
+      };
     } catch (e) {
       this.logger.error('Snapshot sync failed globally', e);
       throw e;

--- a/src/modules/market-data/market-data.service.spec.ts
+++ b/src/modules/market-data/market-data.service.spec.ts
@@ -148,6 +148,31 @@ describe('MarketDataService', () => {
     }),
   };
 
+  // Fresh ticker repo mock factory — exposed so individual tests can override
+  // `getRawMany` (used by pickStaleSnapshotTickers).
+  const mockTickerQb: any = {
+    where: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    leftJoinAndMapOne: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawAndEntities: jest.fn().mockResolvedValue({ entities: [], raw: [] }),
+    getCount: jest.fn().mockResolvedValue(0),
+    getMany: jest.fn().mockResolvedValue([]),
+    getRawMany: jest.fn().mockResolvedValue([]),
+  };
+  const mockTickerRepo = {
+    createQueryBuilder: jest.fn(() => mockTickerQb),
+  };
+
   const mockConfigService = {
     get: jest.fn().mockReturnValue(15), // Return default number
   };
@@ -217,26 +242,7 @@ describe('MarketDataService', () => {
         },
         {
           provide: getRepositoryToken(TickerEntity),
-          useValue: {
-            createQueryBuilder: jest.fn(() => ({
-              where: jest.fn().mockReturnThis(),
-              leftJoin: jest.fn().mockReturnThis(),
-              leftJoinAndMapOne: jest.fn().mockReturnThis(),
-              leftJoinAndSelect: jest.fn().mockReturnThis(),
-              orderBy: jest.fn().mockReturnThis(),
-              addOrderBy: jest.fn().mockReturnThis(),
-              addSelect: jest.fn().mockReturnThis(),
-              skip: jest.fn().mockReturnThis(),
-              take: jest.fn().mockReturnThis(),
-              offset: jest.fn().mockReturnThis(),
-              limit: jest.fn().mockReturnThis(),
-              getRawAndEntities: jest
-                .fn()
-                .mockResolvedValue({ entities: [], raw: [] }),
-              getCount: jest.fn().mockResolvedValue(0),
-              getMany: jest.fn().mockResolvedValue([]),
-            })),
-          },
+          useValue: mockTickerRepo,
         },
       ],
     }).compile();
@@ -1014,6 +1020,69 @@ describe('MarketDataService', () => {
       await service.refreshMarketData('MSFT');
 
       expect(mockTickerRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pickStaleSnapshotTickers', () => {
+    it('returns empty when no candidates are passed', async () => {
+      const result = await service.pickStaleSnapshotTickers([], 10);
+      expect(result).toEqual([]);
+      expect(mockTickerQb.getRawMany).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when limit is 0', async () => {
+      const result = await service.pickStaleSnapshotTickers(['AAPL'], 0);
+      expect(result).toEqual([]);
+    });
+
+    it('orders never-synced first, then by oldest MAX(ts), and applies the limit', async () => {
+      const now = Date.now();
+      const oneHourAgo = new Date(now - 3600 * 1000).toISOString();
+      const oneDayAgo = new Date(now - 24 * 3600 * 1000).toISOString();
+      const oneWeekAgo = new Date(now - 7 * 24 * 3600 * 1000).toISOString();
+
+      // NVDA never synced (no row). AAPL fresh-ish, TSLA day-old, MSFT week-old.
+      mockTickerQb.getRawMany.mockResolvedValueOnce([
+        { symbol: 'AAPL', last_ts: oneHourAgo },
+        { symbol: 'TSLA', last_ts: oneDayAgo },
+        { symbol: 'MSFT', last_ts: oneWeekAgo },
+      ]);
+
+      const result = await service.pickStaleSnapshotTickers(
+        ['AAPL', 'TSLA', 'MSFT', 'NVDA'],
+        3,
+      );
+
+      expect(result).toEqual(['NVDA', 'MSFT', 'TSLA']);
+    });
+
+    it('falls back to alphabetical when all candidates are unsynced', async () => {
+      mockTickerQb.getRawMany.mockResolvedValueOnce([]);
+      const result = await service.pickStaleSnapshotTickers(
+        ['TSLA', 'AAPL', 'MSFT'],
+        2,
+      );
+      expect(result).toEqual(['AAPL', 'MSFT']);
+    });
+
+    it('treats a NULL aggregate as never-synced and sorts it ahead', async () => {
+      mockTickerQb.getRawMany.mockResolvedValueOnce([
+        { symbol: 'AAPL', last_ts: null },
+        {
+          symbol: 'TSLA',
+          last_ts: new Date(Date.now() - 3600 * 1000).toISOString(),
+        },
+      ]);
+      const result = await service.pickStaleSnapshotTickers(
+        ['AAPL', 'TSLA'],
+        2,
+      );
+      expect(result).toEqual(['AAPL', 'TSLA']);
+    });
+
+    it('returns empty when limit is negative', async () => {
+      const result = await service.pickStaleSnapshotTickers(['AAPL'], -3);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/modules/market-data/market-data.service.ts
+++ b/src/modules/market-data/market-data.service.ts
@@ -193,6 +193,51 @@ export class MarketDataService {
     return promise;
   }
 
+  /**
+   * Return the N tickers with the oldest (or missing) snapshot data, ordered
+   * stale-first. Used by the snapshot cron to keep each batch inside the
+   * Cloud Run request budget — full coverage happens across multiple cron runs.
+   *
+   * Joins price_ohlcv → tickers via symbol_id and picks MAX(ts) per symbol.
+   * Tickers with no candles at all sort first (never-synced).
+   */
+  async pickStaleSnapshotTickers(
+    candidateSymbols: string[],
+    limit: number,
+  ): Promise<string[]> {
+    if (candidateSymbols.length === 0 || limit <= 0) return [];
+
+    const rows: { symbol: string; last_ts: string | null }[] =
+      await this.tickerRepo
+        .createQueryBuilder('t')
+        .leftJoin(PriceOhlcv, 'o', 'o.symbol_id = t.id AND o.timeframe = :tf', {
+          tf: '1d',
+        })
+        .select('t.symbol', 'symbol')
+        .addSelect('MAX(o.ts)', 'last_ts')
+        .where('t.symbol IN (:...symbols)', { symbols: candidateSymbols })
+        .groupBy('t.symbol')
+        .getRawMany();
+
+    const lastTsBySymbol = new Map<string, number>();
+    for (const r of rows) {
+      if (r.last_ts) {
+        lastTsBySymbol.set(r.symbol, new Date(r.last_ts).getTime());
+      }
+    }
+
+    return [...candidateSymbols]
+      .sort((a, b) => {
+        const aTs = lastTsBySymbol.get(a);
+        const bTs = lastTsBySymbol.get(b);
+        if (aTs === undefined && bTs === undefined) return a.localeCompare(b);
+        if (aTs === undefined) return -1;
+        if (bTs === undefined) return 1;
+        return aTs - bTs;
+      })
+      .slice(0, limit);
+  }
+
   async refreshMarketData(symbol: string) {
     return this.performGetSnapshot(symbol.toUpperCase(), {
       force: true,

--- a/src/modules/stocktwits/stocktwits.controller.spec.ts
+++ b/src/modules/stocktwits/stocktwits.controller.spec.ts
@@ -14,6 +14,8 @@ describe('StockTwitsController', () => {
     analyzeComments: jest.fn(),
     getLatestAnalysis: jest.fn(),
     getFutureEvents: jest.fn(),
+    handleHourlyPostsSync: jest.fn(),
+    handleDailyWatchersSync: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -56,6 +58,34 @@ describe('StockTwitsController', () => {
         {},
       );
       expect(result).toEqual({ message: 'Not enough data to analyze' });
+    });
+  });
+
+  describe('cron endpoints', () => {
+    it('handleHourlyPostsSync returns batch stats from service', async () => {
+      const stats = { batchSize: 10, processed: 9, failed: 1 };
+      mockService.handleHourlyPostsSync.mockResolvedValue(stats);
+
+      const result = await controller.handleHourlyPostsSync();
+
+      expect(mockService.handleHourlyPostsSync).toHaveBeenCalled();
+      expect(result).toEqual({
+        message: 'Hourly posts sync batch completed',
+        stats,
+      });
+    });
+
+    it('handleDailyWatchersSync returns batch stats from service', async () => {
+      const stats = { batchSize: 25, processed: 25, failed: 0 };
+      mockService.handleDailyWatchersSync.mockResolvedValue(stats);
+
+      const result = await controller.handleDailyWatchersSync();
+
+      expect(mockService.handleDailyWatchersSync).toHaveBeenCalled();
+      expect(result).toEqual({
+        message: 'Daily watchers sync batch completed',
+        stats,
+      });
     });
   });
 });

--- a/src/modules/stocktwits/stocktwits.controller.ts
+++ b/src/modules/stocktwits/stocktwits.controller.ts
@@ -112,23 +112,31 @@ export class StockTwitsController {
   @Post('jobs/sync-posts')
   @Public()
   @UseGuards(CronSecretGuard)
-  @ApiOperation({ summary: 'Trigger hourly posts sync (Cron)' })
+  @ApiOperation({
+    summary: 'Trigger hourly posts sync batch (Cron)',
+    description:
+      'Processes a batch of the most-stale tickers. Hourly cron rotates through all tickers over multiple runs to stay inside the Cloud Run request timeout.',
+  })
   @ApiHeader({ name: 'X-Cron-Secret', required: true })
-  @ApiResponse({ status: 200, description: 'Job started' })
+  @ApiResponse({ status: 200, description: 'Batch completed' })
   async handleHourlyPostsSync() {
-    await this.stockTwitsService.handleHourlyPostsSync();
-    return { message: 'Hourly posts sync completed' };
+    const stats = await this.stockTwitsService.handleHourlyPostsSync();
+    return { message: 'Hourly posts sync batch completed', stats };
   }
 
   @Post('jobs/sync-watchers')
   @Public()
   @UseGuards(CronSecretGuard)
-  @ApiOperation({ summary: 'Trigger daily watchers sync (Cron)' })
+  @ApiOperation({
+    summary: 'Trigger daily watchers sync batch (Cron)',
+    description:
+      'Processes a batch of the most-stale tickers. Daily cron rotates through all tickers over multiple runs.',
+  })
   @ApiHeader({ name: 'X-Cron-Secret', required: true })
-  @ApiResponse({ status: 200, description: 'Job started' })
+  @ApiResponse({ status: 200, description: 'Batch completed' })
   async handleDailyWatchersSync() {
-    await this.stockTwitsService.handleDailyWatchersSync();
-    return { message: 'Daily watchers sync completed' };
+    const stats = await this.stockTwitsService.handleDailyWatchersSync();
+    return { message: 'Daily watchers sync batch completed', stats };
   }
 
   // --- AI Analysis Endpoints ---

--- a/src/modules/stocktwits/stocktwits.service.spec.ts
+++ b/src/modules/stocktwits/stocktwits.service.spec.ts
@@ -16,10 +16,28 @@ describe('StockTwitsService', () => {
   let llmService: LlmService;
   let analysisRepo: any;
   let calendarRepo: any;
+  let postsRepo: any;
+  let watchersRepo: any;
 
   const mockHttpService = {
     get: jest.fn().mockReturnValue(of({ data: { messages: [] } })),
   };
+
+  // Flexible query builder that supports both DELETE chains (used by
+  // analyzeComments) and aggregate SELECT chains (used by the staleness
+  // pickers). Each test can override `getRawMany` to return staleness rows.
+  const buildQb = () => ({
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected: 1 }),
+    getRawMany: jest.fn().mockResolvedValue([]),
+  });
 
   const mockRepo = {
     find: jest.fn(),
@@ -30,13 +48,7 @@ describe('StockTwitsService', () => {
       .mockImplementation((dto) => Promise.resolve({ id: '1', ...dto })),
     findAndCount: jest.fn(),
     delete: jest.fn().mockResolvedValue({ affected: 1 }),
-    createQueryBuilder: jest.fn().mockReturnValue({
-      delete: jest.fn().mockReturnThis(),
-      from: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      execute: jest.fn().mockResolvedValue({ affected: 1 }),
-    }),
+    createQueryBuilder: jest.fn(() => buildQb()),
   };
 
   const mockTickersService = {
@@ -73,6 +85,12 @@ describe('StockTwitsService', () => {
     llmService = module.get<LlmService>(LlmService);
     analysisRepo = module.get(getRepositoryToken(StocktwitsAnalysis));
     calendarRepo = module.get(getRepositoryToken(EventCalendar));
+    postsRepo = module.get(getRepositoryToken(StockTwitsPost));
+    watchersRepo = module.get(getRepositoryToken(StockTwitsWatcher));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -164,6 +182,276 @@ describe('StockTwitsService', () => {
       expect(calendarRepo.save).toHaveBeenCalled();
 
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('pickStaleTickersForPostsSync', () => {
+    it('orders never-synced tickers first, then by oldest MAX(inserted_at)', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'TSLA' },
+        { symbol: 'MSFT' },
+        { symbol: 'NVDA' },
+      ]);
+
+      // AAPL: synced yesterday, TSLA: synced 1h ago, MSFT: never, NVDA: synced 5d ago.
+      const now = Date.now();
+      const yesterday = new Date(now - 24 * 3600 * 1000).toISOString();
+      const oneHourAgo = new Date(now - 3600 * 1000).toISOString();
+      const fiveDaysAgo = new Date(now - 5 * 24 * 3600 * 1000).toISOString();
+
+      postsRepo.createQueryBuilder.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { symbol: 'AAPL', last_sync: yesterday },
+          { symbol: 'TSLA', last_sync: oneHourAgo },
+          { symbol: 'NVDA', last_sync: fiveDaysAgo },
+        ]),
+      });
+
+      const result = await service.pickStaleTickersForPostsSync(3);
+
+      // MSFT (never) → NVDA (oldest) → AAPL → TSLA (newest). Limit 3 cuts TSLA off.
+      expect(result).toEqual(['MSFT', 'NVDA', 'AAPL']);
+    });
+
+    it('returns empty when there are no tickers', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([]);
+      const result = await service.pickStaleTickersForPostsSync(10);
+      expect(result).toEqual([]);
+    });
+
+    it('falls back to alphabetical for tickers that all share the never-synced state', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'TSLA' },
+        { symbol: 'AAPL' },
+        { symbol: 'MSFT' },
+      ]);
+      postsRepo.createQueryBuilder.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.pickStaleTickersForPostsSync(10);
+      expect(result).toEqual(['AAPL', 'MSFT', 'TSLA']);
+    });
+
+    it('drops tickers that have no symbol property', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: undefined },
+        { symbol: '' },
+        { symbol: 'MSFT' },
+      ]);
+      postsRepo.createQueryBuilder.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.pickStaleTickersForPostsSync(10);
+      expect(result).toEqual(['AAPL', 'MSFT']);
+    });
+
+    it('skips rows whose last_sync column came back null', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'TSLA' },
+      ]);
+      // Simulate Postgres returning a row with a NULL aggregate (no posts yet).
+      postsRepo.createQueryBuilder.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { symbol: 'AAPL', last_sync: null },
+          {
+            symbol: 'TSLA',
+            last_sync: new Date(Date.now() - 3600 * 1000).toISOString(),
+          },
+        ]),
+      });
+
+      // AAPL treated as never-synced (last_sync null) so it sorts first.
+      const result = await service.pickStaleTickersForPostsSync(2);
+      expect(result).toEqual(['AAPL', 'TSLA']);
+    });
+  });
+
+  describe('trackWatchers', () => {
+    it('saves a watcher row with the count returned by the StockTwits API', async () => {
+      mockHttpService.get.mockReturnValueOnce(
+        of({
+          data: { symbol: { watchlist_count: 12345 } },
+        }),
+      );
+
+      await service.trackWatchers('AAPL');
+
+      expect(mockHttpService.get).toHaveBeenCalledWith(
+        expect.stringContaining('/AAPL.json'),
+        expect.objectContaining({ timeout: 5000 }),
+      );
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ symbol: 'AAPL', count: 12345 }),
+      );
+    });
+
+    it('rejects an invalid symbol before making an HTTP call', async () => {
+      await expect(service.trackWatchers('bad symbol!')).rejects.toThrow(
+        'Invalid symbol format',
+      );
+      expect(mockHttpService.get).not.toHaveBeenCalled();
+    });
+
+    it('silently exits when the API response is missing watchlist_count', async () => {
+      mockHttpService.get.mockReturnValueOnce(
+        of({ data: { symbol: { id: 1 } } }),
+      );
+      mockRepo.save.mockClear();
+
+      await service.trackWatchers('AAPL');
+
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getFutureEvents', () => {
+    it('queries calendar for symbol + today onwards, oldest first', async () => {
+      mockRepo.find.mockResolvedValueOnce([{ id: 1 }]);
+      const result = await service.getFutureEvents('AAPL');
+      expect(mockRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ symbol: 'AAPL' }),
+          order: { event_date: 'ASC' },
+          take: 10,
+        }),
+      );
+      expect(result).toEqual([{ id: 1 }]);
+    });
+  });
+
+  describe('pickStaleTickersForWatchersSync', () => {
+    it('orders never-synced first, then by oldest MAX(timestamp)', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'TSLA' },
+        { symbol: 'MSFT' },
+      ]);
+      const now = Date.now();
+      const oneHourAgo = new Date(now - 3600 * 1000).toISOString();
+      const oneDayAgo = new Date(now - 24 * 3600 * 1000).toISOString();
+
+      watchersRepo.createQueryBuilder.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { symbol: 'AAPL', last_sync: oneHourAgo },
+          { symbol: 'TSLA', last_sync: oneDayAgo },
+        ]),
+      });
+
+      // MSFT never-synced → first. TSLA older than AAPL → second. Limit 2 drops AAPL.
+      const result = await service.pickStaleTickersForWatchersSync(2);
+      expect(result).toEqual(['MSFT', 'TSLA']);
+    });
+
+    it('returns empty when there are no tickers', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([]);
+      const result = await service.pickStaleTickersForWatchersSync(10);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('handleHourlyPostsSync', () => {
+    it('processes only the staleness-picked batch and returns stats', async () => {
+      jest
+        .spyOn(service, 'pickStaleTickersForPostsSync')
+        .mockResolvedValue(['AAPL', 'TSLA']);
+      const fetchSpy = jest
+        .spyOn(service, 'fetchAndStorePosts')
+        .mockResolvedValue(undefined);
+
+      const stats = await service.handleHourlyPostsSync(2);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy).toHaveBeenCalledWith('AAPL', 20);
+      expect(fetchSpy).toHaveBeenCalledWith('TSLA', 20);
+      expect(stats).toEqual({ batchSize: 2, processed: 2, failed: 0 });
+    });
+
+    it('isolates per-ticker errors so a bad ticker cannot abort the batch', async () => {
+      jest
+        .spyOn(service, 'pickStaleTickersForPostsSync')
+        .mockResolvedValue(['AAPL', 'BAD', 'TSLA']);
+      const fetchSpy = jest
+        .spyOn(service, 'fetchAndStorePosts')
+        .mockImplementation((symbol: string) =>
+          symbol === 'BAD'
+            ? Promise.reject(new Error('boom'))
+            : Promise.resolve(undefined),
+        );
+
+      const stats = await service.handleHourlyPostsSync(3);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(stats).toEqual({ batchSize: 3, processed: 2, failed: 1 });
+    });
+
+    it('returns zero-stats when there are no tickers to sync', async () => {
+      jest.spyOn(service, 'pickStaleTickersForPostsSync').mockResolvedValue([]);
+      const fetchSpy = jest.spyOn(service, 'fetchAndStorePosts');
+
+      const stats = await service.handleHourlyPostsSync(10);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(stats).toEqual({ batchSize: 0, processed: 0, failed: 0 });
+    });
+  });
+
+  describe('handleDailyWatchersSync', () => {
+    it('processes only the staleness-picked batch and returns stats', async () => {
+      jest
+        .spyOn(service, 'pickStaleTickersForWatchersSync')
+        .mockResolvedValue(['AAPL', 'TSLA']);
+      const trackSpy = jest
+        .spyOn(service, 'trackWatchers')
+        .mockResolvedValue(undefined);
+
+      const stats = await service.handleDailyWatchersSync(2);
+
+      expect(trackSpy).toHaveBeenCalledTimes(2);
+      expect(trackSpy).toHaveBeenCalledWith('AAPL');
+      expect(trackSpy).toHaveBeenCalledWith('TSLA');
+      expect(stats).toEqual({ batchSize: 2, processed: 2, failed: 0 });
+    });
+
+    it('isolates per-ticker errors', async () => {
+      jest
+        .spyOn(service, 'pickStaleTickersForWatchersSync')
+        .mockResolvedValue(['AAPL', 'BAD']);
+      jest
+        .spyOn(service, 'trackWatchers')
+        .mockImplementation((symbol: string) =>
+          symbol === 'BAD'
+            ? Promise.reject(new Error('boom'))
+            : Promise.resolve(undefined),
+        );
+
+      const stats = await service.handleDailyWatchersSync(2);
+
+      expect(stats).toEqual({ batchSize: 2, processed: 1, failed: 1 });
     });
   });
 });

--- a/src/modules/stocktwits/stocktwits.service.ts
+++ b/src/modules/stocktwits/stocktwits.service.ts
@@ -301,34 +301,171 @@ export class StockTwitsService {
   // --- Scanners / Cron Jobs ---
 
   /**
-   * Hourly: Sync posts for all tickers
+   * Batch size defaults — sized so a single cron run finishes well inside the
+   * Cloud Run 5-min request timeout. Posts is the heavy path (up to 20 pages
+   * each × HTTP latency), watchers is light (1 GET per ticker).
    */
+  static readonly POSTS_BATCH_SIZE = 10;
+  static readonly WATCHERS_BATCH_SIZE = 25;
 
-  async handleHourlyPostsSync() {
-    this.logger.log('Starting Hourly StockTwits Post Sync...');
-    const tickers = await this.tickersService.getAllTickers();
-    for (const ticker of tickers) {
-      if (ticker.symbol) {
-        await this.fetchAndStorePosts(ticker.symbol, 20); // Limit 20 pages for cron
+  /**
+   * Pick the N tickers whose latest post is oldest (or that have never been
+   * synced). Used by the hourly batch cron so each run advances coverage
+   * without blowing the request budget.
+   */
+  async pickStaleTickersForPostsSync(limit: number): Promise<string[]> {
+    const allTickers = await this.tickersService.getAllTickers();
+    const symbols = allTickers
+      .map((t) => t.symbol)
+      .filter((s): s is string => !!s);
+
+    if (symbols.length === 0) return [];
+
+    const rows: { symbol: string; last_sync: string | null }[] =
+      await this.postsRepository
+        .createQueryBuilder('p')
+        .select('p.symbol', 'symbol')
+        .addSelect('MAX(p.inserted_at)', 'last_sync')
+        .where('p.symbol IN (:...symbols)', { symbols })
+        .groupBy('p.symbol')
+        .getRawMany();
+
+    const lastSyncBySymbol = new Map<string, number>();
+    for (const r of rows) {
+      if (r.last_sync) {
+        lastSyncBySymbol.set(r.symbol, new Date(r.last_sync).getTime());
       }
     }
-    this.logger.log('Hourly Post Sync Complete.');
+
+    // Sort: never-synced first, then oldest-synced. Stable alphabetical tiebreak.
+    return [...symbols]
+      .sort((a, b) => {
+        const aTs = lastSyncBySymbol.get(a);
+        const bTs = lastSyncBySymbol.get(b);
+        if (aTs === undefined && bTs === undefined) return a.localeCompare(b);
+        if (aTs === undefined) return -1;
+        if (bTs === undefined) return 1;
+        return aTs - bTs;
+      })
+      .slice(0, limit);
   }
 
   /**
-   * Daily: Sync watcher counts for all tickers
-   * Runs at midnight.
+   * Pick the N tickers whose latest watcher record is oldest (or missing).
    */
+  async pickStaleTickersForWatchersSync(limit: number): Promise<string[]> {
+    const allTickers = await this.tickersService.getAllTickers();
+    const symbols = allTickers
+      .map((t) => t.symbol)
+      .filter((s): s is string => !!s);
 
-  async handleDailyWatchersSync() {
-    this.logger.log('Starting Daily StockTwits Watcher Sync...');
-    const tickers = await this.tickersService.getAllTickers();
-    for (const ticker of tickers) {
-      if (ticker.symbol) {
-        await this.trackWatchers(ticker.symbol);
+    if (symbols.length === 0) return [];
+
+    const rows: { symbol: string; last_sync: string | null }[] =
+      await this.watchersRepository
+        .createQueryBuilder('w')
+        .select('w.symbol', 'symbol')
+        .addSelect('MAX(w.timestamp)', 'last_sync')
+        .where('w.symbol IN (:...symbols)', { symbols })
+        .groupBy('w.symbol')
+        .getRawMany();
+
+    const lastSyncBySymbol = new Map<string, number>();
+    for (const r of rows) {
+      if (r.last_sync) {
+        lastSyncBySymbol.set(r.symbol, new Date(r.last_sync).getTime());
       }
     }
-    this.logger.log('Daily Watcher Sync Complete.');
+
+    return [...symbols]
+      .sort((a, b) => {
+        const aTs = lastSyncBySymbol.get(a);
+        const bTs = lastSyncBySymbol.get(b);
+        if (aTs === undefined && bTs === undefined) return a.localeCompare(b);
+        if (aTs === undefined) return -1;
+        if (bTs === undefined) return 1;
+        return aTs - bTs;
+      })
+      .slice(0, limit);
+  }
+
+  /**
+   * Hourly batch: sync posts for the N most-stale tickers. Each run processes
+   * a small slice; the hourly cron rotates through the universe over multiple
+   * runs. Returns stats so the cron caller can log progress.
+   *
+   * fetchAndStorePosts already catches its own errors, so a single bad ticker
+   * cannot abort the batch.
+   */
+  async handleHourlyPostsSync(
+    batchSize = StockTwitsService.POSTS_BATCH_SIZE,
+  ): Promise<{ batchSize: number; processed: number; failed: number }> {
+    this.logger.log(
+      `Starting StockTwits posts batch sync (size: ${batchSize})...`,
+    );
+    const symbols = await this.pickStaleTickersForPostsSync(batchSize);
+    if (symbols.length === 0) {
+      this.logger.log('No tickers to sync.');
+      return { batchSize: 0, processed: 0, failed: 0 };
+    }
+    this.logger.log(`Batch tickers: ${symbols.join(', ')}`);
+
+    let processed = 0;
+    let failed = 0;
+    for (const symbol of symbols) {
+      try {
+        await this.fetchAndStorePosts(symbol, 20); // 20 pages cap for cron
+        processed++;
+      } catch (e: any) {
+        // Defensive: fetchAndStorePosts has its own try/catch, but never let
+        // a leaked error abort the rest of the batch.
+        this.logger.error(
+          `Posts batch failed for ${symbol}: ${e?.message || e}`,
+        );
+        failed++;
+      }
+    }
+
+    this.logger.log(
+      `Posts batch complete. Processed: ${processed}, Failed: ${failed} of ${symbols.length}.`,
+    );
+    return { batchSize: symbols.length, processed, failed };
+  }
+
+  /**
+   * Daily batch: sync watcher counts for the N most-stale tickers.
+   */
+  async handleDailyWatchersSync(
+    batchSize = StockTwitsService.WATCHERS_BATCH_SIZE,
+  ): Promise<{ batchSize: number; processed: number; failed: number }> {
+    this.logger.log(
+      `Starting StockTwits watchers batch sync (size: ${batchSize})...`,
+    );
+    const symbols = await this.pickStaleTickersForWatchersSync(batchSize);
+    if (symbols.length === 0) {
+      this.logger.log('No tickers to sync.');
+      return { batchSize: 0, processed: 0, failed: 0 };
+    }
+    this.logger.log(`Batch tickers: ${symbols.join(', ')}`);
+
+    let processed = 0;
+    let failed = 0;
+    for (const symbol of symbols) {
+      try {
+        await this.trackWatchers(symbol);
+        processed++;
+      } catch (e: any) {
+        this.logger.error(
+          `Watchers batch failed for ${symbol}: ${e?.message || e}`,
+        );
+        failed++;
+      }
+    }
+
+    this.logger.log(
+      `Watchers batch complete. Processed: ${processed}, Failed: ${failed} of ${symbols.length}.`,
+    );
+    return { batchSize: symbols.length, processed, failed };
   }
 
   async getPosts(symbol: string, page = 1, limit = 50) {

--- a/src/scripts/benchmark-gemini-deep.ts
+++ b/src/scripts/benchmark-gemini-deep.ts
@@ -1,0 +1,168 @@
+import { GoogleGenAI } from '@google/genai';
+import * as dotenv from 'dotenv';
+import { Chalk } from 'chalk';
+
+dotenv.config();
+const chalk = new Chalk({ level: 3 });
+
+const ITERS = 5;
+
+// The handful that came back ambiguous in the first sweep:
+// - gemini-3-pro-preview: 429 once → is this hard-quota or transient?
+// - gemma-4-31b-it: 500 on short prompt, 200 on long → flaky?
+// - gemini-3.1-flash-lite: works, but is it on the docs sheet? confirm stability
+// Plus the production-realistic extraction prompt used by research.service.ts.
+const MODELS = [
+  'gemini-2.5-flash-lite',
+  'gemini-2.5-flash',
+  'gemini-3-flash-preview',
+  'gemini-3-pro-preview',
+  'gemini-3.1-flash-lite',
+  'gemma-4-26b-a4b-it',
+  'gemma-4-31b-it',
+];
+
+const PROD_EXTRACTION_PROMPT = `You are a strict data extraction engine.
+Given the research note below, return ONLY valid JSON. No prose, no markdown fences.
+Schema:
+{
+  "ticker": string,
+  "company": string,
+  "description": string,
+  "metrics": { "revenue_ttm_usd": number|null, "operating_margin_pct": number|null },
+  "risks": string[],
+  "sentiment": "bullish"|"bearish"|"neutral"
+}
+
+Research note:
+Apple Inc. (AAPL) reported fiscal Q4 2025 revenue of $94.93B, up 6% YoY.
+Services hit a record $24.97B. Operating margin expanded ~120bps to 31.5%.
+iPhone unit growth was flat in China; FX headwinds continue. Analyst tone bullish into the holiday quarter.`;
+
+type Run = {
+  ok: boolean;
+  ms: number;
+  status: number | string;
+  preview: string;
+  jsonOk: boolean;
+};
+
+async function call(client: GoogleGenAI, model: string): Promise<Run> {
+  const start = Date.now();
+  try {
+    const r = await client.models.generateContent({
+      model,
+      contents: [{ role: 'user', parts: [{ text: PROD_EXTRACTION_PROMPT }] }],
+      config: { maxOutputTokens: 600 },
+    });
+    const txt = r.text || '';
+    let jsonOk = false;
+    const m = txt.match(/\{[\s\S]*\}/);
+    if (m) {
+      try {
+        const o = JSON.parse(m[0]);
+        jsonOk =
+          typeof o.ticker === 'string' &&
+          typeof o.company === 'string' &&
+          typeof o.sentiment === 'string' &&
+          Array.isArray(o.risks) &&
+          o.metrics &&
+          typeof o.metrics === 'object';
+      } catch {
+        jsonOk = false;
+      }
+    }
+    return {
+      ok: txt.length > 0,
+      ms: Date.now() - start,
+      status: 200,
+      preview: txt.slice(0, 160).replace(/\s+/g, ' '),
+      jsonOk,
+    };
+  } catch (err: any) {
+    return {
+      ok: false,
+      ms: Date.now() - start,
+      status: err?.status ?? err?.code ?? 'ERR',
+      preview: (err?.message || '').slice(0, 160),
+      jsonOk: false,
+    };
+  }
+}
+
+async function main() {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    console.error(chalk.red('GEMINI_API_KEY missing'));
+    process.exit(1);
+  }
+  const client = new GoogleGenAI({ apiKey });
+
+  console.log(
+    chalk.bold.cyan(
+      `\nDeep extraction benchmark — ${MODELS.length} models × ${ITERS} runs (production-shaped JSON prompt)\n`,
+    ),
+  );
+
+  const summary: any[] = [];
+  for (const m of MODELS) {
+    const runs: Run[] = [];
+    process.stdout.write(chalk.yellow(m.padEnd(28)) + ' ');
+    for (let i = 0; i < ITERS; i++) {
+      const r = await call(client, m);
+      runs.push(r);
+      process.stdout.write(
+        r.ok && r.jsonOk
+          ? chalk.green('✓')
+          : r.ok
+            ? chalk.yellow('~')
+            : chalk.red('✗'),
+      );
+      await new Promise((res) => setTimeout(res, 1200)); // be polite vs free-tier RPM
+    }
+    process.stdout.write('\n');
+    const ok = runs.filter((r) => r.ok).length;
+    const jsonOk = runs.filter((r) => r.jsonOk).length;
+    const avgMs = ok
+      ? Math.round(runs.filter((r) => r.ok).reduce((a, r) => a + r.ms, 0) / ok)
+      : 0;
+    const errs = runs.filter((r) => !r.ok).map((r) => r.status);
+    summary.push({
+      Model: m,
+      Pass: `${ok}/${ITERS}`,
+      JSON: `${jsonOk}/${ITERS}`,
+      AvgMs: avgMs || '-',
+      ErrorStatuses: errs.join(',') || '-',
+    });
+  }
+
+  console.log(chalk.bold.cyan('\nSummary:\n'));
+  console.table(summary);
+
+  console.log(chalk.bold.cyan('\nVerdict:'));
+  for (const row of summary) {
+    const pass = parseInt(row.Pass.split('/')[0], 10);
+    const json = parseInt(row.JSON.split('/')[0], 10);
+    if (pass === 0)
+      console.log(
+        `  ${chalk.red('DEAD')}      ${row.Model}  (status ${row.ErrorStatuses})`,
+      );
+    else if (pass < ITERS)
+      console.log(
+        `  ${chalk.yellow('FLAKY')}     ${row.Model}  (${row.Pass}, errs=${row.ErrorStatuses})`,
+      );
+    else if (json < ITERS)
+      console.log(
+        `  ${chalk.yellow('JSON-WEAK')} ${row.Model}  (extracts: ${row.JSON})`,
+      );
+    else
+      console.log(
+        `  ${chalk.green('OK')}        ${row.Model}  (${row.AvgMs}ms avg)`,
+      );
+  }
+}
+
+main().catch((e) => {
+  console.error(chalk.red('Crashed:'), e);
+  process.exit(1);
+});

--- a/src/scripts/benchmark-gemini.ts
+++ b/src/scripts/benchmark-gemini.ts
@@ -1,0 +1,186 @@
+import { GoogleGenAI } from '@google/genai';
+import * as dotenv from 'dotenv';
+import { Chalk } from 'chalk';
+
+dotenv.config();
+const chalk = new Chalk({ level: 3 });
+
+type CallResult = {
+  ok: boolean;
+  ms: number;
+  bytes: number;
+  status?: number | string;
+  message?: string;
+  preview?: string;
+};
+
+// All models we currently reference in the codebase + the ones the
+// Gemini docs claim to be available on this key.
+const MODELS_FROM_CODE: string[] = [
+  // configuration.ts defaults
+  'gemini-2.5-flash-lite',
+  'gemini-3-flash-preview',
+  'gemini-3-pro-preview',
+  'gemma-4-26b-a4b-it',
+  'gemini-3.1-flash-lite',
+  'gemma-4-31b-it',
+  // gemini.provider.ts hard-coded
+  'gemini-2.5-flash',
+];
+
+const MODELS_FROM_DOCS: string[] = [
+  'gemini-2.5-flash-lite',
+  'gemini-2.5-flash',
+  'gemini-3-flash-preview',
+  'gemini-3-pro',
+  'gemma-3-1b',
+  'gemma-3-2b',
+  'gemma-3-4b',
+  'gemma-3-12b',
+  'gemma-3-27b',
+];
+
+const ALL_MODELS = Array.from(
+  new Set<string>([...MODELS_FROM_CODE, ...MODELS_FROM_DOCS]),
+);
+
+const EXTRACTION_PROMPT = `You are a strict data extraction engine.
+Return ONLY a JSON object (no markdown, no commentary) with this exact shape:
+{"ticker":"AAPL","price":number,"sentiment":"bullish"|"bearish"|"neutral"}
+
+Source text:
+Apple Inc. (AAPL) closed at $189.42 today amid optimistic analyst upgrades.`;
+
+const SIMPLE_PROMPT = 'Reply with the single word: OK';
+
+function classify(err: any): { status: number | string; msg: string } {
+  const status = err?.status ?? err?.code ?? err?.response?.status ?? 'ERR';
+  const msg =
+    err?.error?.message ||
+    err?.response?.data?.error?.message ||
+    err?.message ||
+    String(err);
+  return { status, msg: msg.slice(0, 240) };
+}
+
+async function callModel(
+  client: GoogleGenAI,
+  model: string,
+  prompt: string,
+): Promise<CallResult> {
+  const start = Date.now();
+  try {
+    const resp = await client.models.generateContent({
+      model,
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      config: { maxOutputTokens: 256 },
+    });
+    const text = resp.text || '';
+    return {
+      ok: text.length > 0,
+      ms: Date.now() - start,
+      bytes: text.length,
+      preview: text.slice(0, 120).replace(/\s+/g, ' '),
+      status: text.length > 0 ? 200 : 'EMPTY',
+    };
+  } catch (err: any) {
+    const { status, msg } = classify(err);
+    return {
+      ok: false,
+      ms: Date.now() - start,
+      bytes: 0,
+      status,
+      message: msg,
+    };
+  }
+}
+
+function fmtStatus(ok: boolean, status: number | string | undefined): string {
+  if (ok) return chalk.green(`✓ ${status ?? 200}`);
+  return chalk.red(`✗ ${status ?? 'ERR'}`);
+}
+
+async function main() {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    console.error(chalk.red('FATAL: GEMINI_API_KEY missing in .env'));
+    process.exit(1);
+  }
+  const client = new GoogleGenAI({ apiKey });
+
+  console.log(
+    chalk.bold.cyan(
+      `\nGemini API key benchmark — ${ALL_MODELS.length} models × 2 calls (simple + JSON extraction)\n`,
+    ),
+  );
+
+  const rows: Array<Record<string, string>> = [];
+
+  for (const model of ALL_MODELS) {
+    process.stdout.write(chalk.yellow(model.padEnd(28)));
+    const simple = await callModel(client, model, SIMPLE_PROMPT);
+    process.stdout.write(' simple=' + fmtStatus(simple.ok, simple.status));
+    const extract = await callModel(client, model, EXTRACTION_PROMPT);
+    process.stdout.write(
+      '  extract=' + fmtStatus(extract.ok, extract.status) + '\n',
+    );
+
+    let extractValid = false;
+    if (extract.ok && extract.preview) {
+      const m = extract.preview.match(/\{[\s\S]*\}/);
+      if (m) {
+        try {
+          const obj = JSON.parse(m[0]);
+          extractValid =
+            typeof obj.ticker === 'string' &&
+            typeof obj.price === 'number' &&
+            typeof obj.sentiment === 'string';
+        } catch {
+          extractValid = false;
+        }
+      }
+    }
+
+    rows.push({
+      Model: model,
+      Simple: simple.ok ? `OK ${simple.ms}ms` : `FAIL ${simple.status}`,
+      Extract: extract.ok ? `OK ${extract.ms}ms` : `FAIL ${extract.status}`,
+      'JSON valid': extract.ok ? (extractValid ? 'yes' : 'NO') : '-',
+      Error: (simple.message || extract.message || '').slice(0, 90),
+    });
+  }
+
+  console.log(chalk.bold.cyan('\nResults:\n'));
+  console.table(rows);
+
+  const dead = rows.filter((r) => r.Simple.startsWith('FAIL'));
+  const extractBroken = rows.filter(
+    (r) => !r.Simple.startsWith('FAIL') && r['JSON valid'] === 'NO',
+  );
+  const extractFails = rows.filter(
+    (r) => !r.Simple.startsWith('FAIL') && r.Extract.startsWith('FAIL'),
+  );
+
+  console.log(chalk.bold.red('\nDead models (simple call fails):'));
+  if (dead.length === 0) console.log(chalk.green('  none'));
+  for (const r of dead) console.log(`  - ${r.Model}  (${r.Error})`);
+
+  console.log(
+    chalk.bold.yellow(
+      '\nWorking but extraction call fails (e.g. quota on long output):',
+    ),
+  );
+  if (extractFails.length === 0) console.log(chalk.green('  none'));
+  for (const r of extractFails) console.log(`  - ${r.Model}  (${r.Error})`);
+
+  console.log(
+    chalk.bold.yellow('\nWorking but produced invalid JSON for extraction:'),
+  );
+  if (extractBroken.length === 0) console.log(chalk.green('  none'));
+  for (const r of extractBroken) console.log(`  - ${r.Model}`);
+}
+
+main().catch((e) => {
+  console.error(chalk.red('Benchmark crashed:'), e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes the production cron failure (`POST /api/v1/stocktwits/jobs/sync-posts` → 500) plus two related endpoints with the same anti-pattern, plus a CI workflow bug that produced confusing "operation was canceled" errors.

## Root causes

1. **sync-posts 500**: controller `await`ed a sequential loop over ALL tickers (~100+) × up to 20 pages × HTTP latency → exceeded Cloud Run's 5-min request budget → platform terminated → 500.
2. **sync-watchers / sync-snapshots**: same "loop over all tickers in foreground" pattern, ready to break the same way as the universe grows.
3. **Cloudflare-bypass \`curl\` fallback** in \`stocktwits.service:116,272\` silently threw ENOENT in prod — \`node:22-alpine\` ships without \`curl\`.
4. **CI test job "operation was canceled" on \`docker pull\`** — default \`fail-fast: true\` killed the surviving matrix leg mid-pull when its sibling failed. The surviving leg's log showed the kill, not the real cause.

## Changes

**Cron fix (\`9c5faef\`)**
- \`stocktwits.service\`: \`pickStaleTickersForPostsSync\` / \`…ForWatchersSync\` order by \`MAX(inserted_at|timestamp)\` with never-synced first; \`handleHourly*\` / \`handleDaily*\` now process only the first N (10 for posts, 25 for watchers) and return \`{ batchSize, processed, failed }\`. Per-ticker errors isolated.
- \`market-data.service\`: \`pickStaleSnapshotTickers\` joins \`price_ohlcv → tickers\`, orders by oldest \`MAX(ts)\`.
- \`jobs.service.syncSnapshots\`: uses the new picker, batch=25, reports \`skippedMarketClosed\`.
- \`stocktwits.controller\`: returns \`{ message, stats }\`.
- \`Dockerfile\`: \`apk add --no-cache curl\` in production stage.
- +10 specs covering staleness ordering, NULL aggregate, limit≤0, error isolation, controller shape. Branch coverage 49.69 → 50.21 %.

**CI hardening (\`768872f\`)**
- \`fail-fast: false\` on all three matrix jobs (lint / test / build) so sibling failures are visible instead of cancelling each other.
- \`concurrency:\` block with \`cancel-in-progress: true\` — fast pushes no longer burn parallel CI minutes on stale commits.
- Test job DB env hardcoded to \`localhost\` / postgres service container values. **Important:** previously env was sourced from \`secrets.DB_HOST\` etc. combined with \`DB_SYNCHRONIZE=true\`, which could rewrite the schema of whatever DB the secret pointed to — including prod.
- Lint matrix harmonized with test/build (Node 20.x + 22.x).

**Also included (\`79f21ac\`)**
- \`src/scripts/benchmark-gemini*.ts\` — gemini model benchmark scripts (separate concern, was already on the branch).

## How it stays inside Cloud Run budget

- Posts batch=10 × ~15 s/ticker ≈ 2.5 min
- Watchers batch=25 × ~1 s/ticker ≈ 25 s
- Snapshots batch=25 × (~1 s + 500 ms delay) ≈ 40 s

Each cron run rotates through the universe via DB-driven staleness — no in-memory cursor, no external queue, safe across Cloud Run instance restarts.

## Test plan

- ✅ \`npm test\` — 459/459 passing locally
- ✅ \`npm run build\` — clean
- ✅ Lint clean
- ✅ Branch coverage above 50 % threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)