### PR TITLE
feat(currency): native-currency display app-wide, Portfolio is the only converter

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -10,7 +10,12 @@ import { useActiveResearchCount } from '../../hooks/useTicker';
 import { GlobalSearch } from './GlobalSearch';
 import { SuperLoading } from '../ui/SuperLoading';
 import { useLocalAnalysisCount } from '../../store/analysisStore';
-import { CurrencySelector } from '../ui/CurrencySelector';
+// CurrencySelector was previously rendered in the Header to set a global
+// "convert everything to this currency" preference. That model was removed:
+// every ticker now displays in its native trading currency app-wide, and
+// the only place that converts is the Portfolio page (with its own local
+// selector). The CurrencySelector component still exists for the Portfolio
+// page; we just don't mount it here.
 
 interface Notification {
   id: string;
@@ -424,10 +429,6 @@ export function Header() {
                     <Brain size={16} />
                     About NeuralTicker
                   </button>
-                </div>
-
-                <div className="border-t border-border">
-                  <CurrencySelector />
                 </div>
 
                 <div className="p-2 border-t border-border">

--- a/frontend/src/components/portfolio/PortfolioCurrencySelector.tsx
+++ b/frontend/src/components/portfolio/PortfolioCurrencySelector.tsx
@@ -1,0 +1,56 @@
+import { Coins } from 'lucide-react';
+import { NativeSelect } from '../ui/select-native';
+import { useCurrency } from '../../context/CurrencyContext';
+
+/**
+ * Sentinel value used by the Portfolio currency dropdown to mean "show every
+ * row in its own native currency — do not convert". Empty string keeps the
+ * DOM `<select>` semantics simple.
+ */
+export const PORTFOLIO_DISPLAY_NATIVE = '';
+
+export interface PortfolioCurrencySelectorProps {
+  /** Empty string = NATIVE, otherwise an ISO currency code (e.g. 'EUR'). */
+  value: string;
+  onChange: (next: string) => void;
+}
+
+/**
+ * Portfolio-local display currency selector with a NATIVE option. Distinct
+ * from the (now-removed) global Header selector — only the Portfolio page
+ * still converts currencies; everywhere else renders natively.
+ */
+export function PortfolioCurrencySelector({
+  value,
+  onChange,
+}: PortfolioCurrencySelectorProps) {
+  const { availableCurrencies, loading } = useCurrency();
+
+  if (loading) {
+    return (
+      <div className="px-2 py-1.5 flex items-center justify-center">
+        <div className="w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <Coins size={14} className="text-muted-foreground" />
+      <span className="text-muted-foreground hidden sm:inline">Display</span>
+      <NativeSelect
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="text-xs h-8 min-w-[110px]"
+        title="Portfolio display currency. NATIVE shows each row in the currency it trades in."
+      >
+        <option value={PORTFOLIO_DISPLAY_NATIVE}>🌐 NATIVE</option>
+        {availableCurrencies.map((currency) => (
+          <option key={currency.code} value={currency.code}>
+            {currency.flag} {currency.code}
+          </option>
+        ))}
+      </NativeSelect>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/PortfolioStats.tsx
+++ b/frontend/src/components/portfolio/PortfolioStats.tsx
@@ -32,6 +32,12 @@ interface PortfolioStatsProps {
   credits?: number;
   todayGain?: number;
   todayGainPct?: number;
+  /** Currency code the totals are denominated in (empty string when NATIVE). */
+  displayCurrency?: string;
+  /** True when the Portfolio is showing each row in its own native currency. */
+  isNativeMode?: boolean;
+  /** Count of rows the backend could not convert (FX rate missing). */
+  conversionUnavailable?: number;
 }
 
 // Professional Palette - Carbon/Minimalist
@@ -104,10 +110,25 @@ export function PortfolioStats({
   positions,
   onAnalyze,
   credits = 0,
+  displayCurrency: portfolioCurrency,
+  isNativeMode = false,
+  conversionUnavailable = 0,
 }: PortfolioStatsProps) {
 
   const [range, setRange] = useState<Range>('1M');
-  const { formatCurrency, displayCurrency } = useCurrency(); // Use context formatter
+  const { formatCurrency: ctxFormatCurrency, displayCurrency: ctxDisplayCurrency } = useCurrency();
+
+  // Prefer the Portfolio-local currency (passed in from the page) over the
+  // context default — the page owns the truth now that the global selector
+  // has been removed.
+  const effectiveCurrency = portfolioCurrency || ctxDisplayCurrency;
+  // In NATIVE mode the totals are a mathematically meaningless sum of values
+  // across different currencies; we render "MIXED" instead.
+  const formatTotal = (val: number): string =>
+    isNativeMode ? 'MIXED' : ctxFormatCurrency(val, effectiveCurrency);
+  const formatCurrency = (val: number): string =>
+    ctxFormatCurrency(val, effectiveCurrency);
+  const displayCurrency = effectiveCurrency;
 
 
   // --- Data Preparation ---
@@ -316,26 +337,49 @@ export function PortfolioStats({
         <div className="lg:col-span-2 rounded-xl border border-border/50 bg-card flex flex-col h-72 lg:h-80">
           <div className="p-6 pb-2 flex justify-between items-start">
             <div>
-              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-widest mb-1">Total Net Worth</p>
+              <p
+                className="text-[11px] font-semibold text-muted-foreground uppercase tracking-widest mb-1"
+                title={
+                  isNativeMode
+                    ? 'Pick a single currency to see totals — summing across currencies is not meaningful.'
+                    : undefined
+                }
+              >
+                Total Net Worth
+              </p>
               <h2 className="text-2xl font-bold tracking-tight text-foreground">
-                {formatCurrency(totalValue)}
+                {formatTotal(totalValue)}
               </h2>
-              <div className={cn(
-                "inline-flex items-center gap-1.5 mt-2 px-2.5 py-1 rounded-md text-xs font-semibold",
-                isProfit
-                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                  : "bg-rose-500/10 text-rose-600 dark:text-rose-400"
-              )}>
-                {isProfit ? <TrendingUp size={14} /> : <TrendingDown size={14} />}
-                {formatCurrency(Math.abs(totalGainLoss))} ({totalGainLossPercent >= 0 ? '+' : ''}{totalGainLossPercent.toFixed(2)}%) <span className="text-muted-foreground ml-1">All Time</span>
-              </div>
+              {isNativeMode ? (
+                <div className="inline-flex items-center gap-1.5 mt-2 px-2.5 py-1 rounded-md text-xs font-semibold bg-muted/60 text-muted-foreground">
+                  Switch from NATIVE to a single currency for totals
+                </div>
+              ) : (
+                <div className={cn(
+                  "inline-flex items-center gap-1.5 mt-2 px-2.5 py-1 rounded-md text-xs font-semibold",
+                  isProfit
+                    ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                    : "bg-rose-500/10 text-rose-600 dark:text-rose-400"
+                )}>
+                  {isProfit ? <TrendingUp size={14} /> : <TrendingDown size={14} />}
+                  {formatCurrency(Math.abs(totalGainLoss))} ({totalGainLossPercent >= 0 ? '+' : ''}{totalGainLossPercent.toFixed(2)}%) <span className="text-muted-foreground ml-1">All Time</span>
+                </div>
+              )}
+              {conversionUnavailable > 0 && !isNativeMode && (
+                <div
+                  className="inline-flex items-center gap-1.5 mt-2 ml-2 px-2 py-0.5 rounded-md text-[11px] font-medium bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20"
+                  title={`FX rate unavailable for ${conversionUnavailable} position(s). Those rows render in their native currency.`}
+                >
+                  {conversionUnavailable} of {positions.length} not converted
+                </div>
+              )}
             </div>
 
             {/* Middle: Invested Amount */}
              <div className="hidden sm:flex flex-col items-center justify-center pt-1">
               <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest mb-0.5">Invested</span>
               <span className="text-xl font-bold text-foreground/80">
-                {formatCurrency(totalValue - totalGainLoss)}
+                {formatTotal(totalValue - totalGainLoss)}
               </span>
             </div>
 

--- a/frontend/src/components/portfolio/PortfolioTable.tsx
+++ b/frontend/src/components/portfolio/PortfolioTable.tsx
@@ -30,6 +30,11 @@ export interface Position {
     original_cost_basis?: number;
     original_gain_loss?: number;
 
+    // Set by the backend when the user requested a displayCurrency but the FX
+    // rate from this row's native currency to displayCurrency was unavailable.
+    // The values above stay in the native currency in that case.
+    conversion_unavailable?: boolean;
+
     // Sparkline & Range
     sparkline?: number[];
     fiftyTwoWeekHigh?: number;
@@ -94,6 +99,7 @@ export function PortfolioTable({ positions, onDelete, onEdit, loading }: Portfol
                 const counts = info.row.original.counts;
                 const row = info.row.original;
                 const currency = row.original_currency || row.ticker?.currency || 'USD';
+                const conversionUnavailable = row.conversion_unavailable;
                 const showCounts = (counts?.research || 0) + (counts?.news || 0) + (counts?.social || 0) > 0;
 
                 return (
@@ -114,6 +120,14 @@ export function PortfolioTable({ positions, onDelete, onEdit, loading }: Portfol
                                 <span className="text-[10px] bg-muted/50 px-1.5 py-0.5 rounded text-muted-foreground font-mono">
                                     {currency}
                                 </span>
+                                {conversionUnavailable && (
+                                    <span
+                                        className="text-[9px] bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/30 px-1.5 py-0.5 rounded font-mono uppercase tracking-wider"
+                                        title={`FX rate unavailable — this row is shown in its native ${currency}, not the selected display currency.`}
+                                    >
+                                        FX UNAVAILABLE
+                                    </span>
+                                )}
 
                                 {showCounts && (
                                     <div className="flex items-center gap-2">

--- a/frontend/src/context/CurrencyContext.test.tsx
+++ b/frontend/src/context/CurrencyContext.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+// `setupTests.ts` globally mocks `./context/CurrencyContext` so any component
+// that calls `useCurrency` outside a real provider doesn't crash. For THIS
+// file we need the real implementation to test it — override with the actual
+// module before importing.
+vi.mock('./CurrencyContext', async () => {
+  const actual =
+    await vi.importActual<typeof import('./CurrencyContext')>('./CurrencyContext');
+  return actual;
+});
+
+import { CurrencyProvider, useCurrency } from './CurrencyContext';
+import { api } from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  // Provide a baseline rate set so any test that does call `convert` works.
+  (api.get as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+    if (url === '/currency/available') {
+      return Promise.resolve({
+        data: {
+          currencies: [
+            { code: 'USD', flag: '🇺🇸' },
+            { code: 'EUR', flag: '🇪🇺' },
+            { code: 'GBP', flag: '🇬🇧' },
+          ],
+        },
+      });
+    }
+    if (url === '/currency/rates') {
+      // 1 USD = 0.92 EUR, 1 USD = 0.79 GBP
+      return Promise.resolve({
+        data: { rates: { EUR: 0.92, GBP: 0.79 } },
+      });
+    }
+    return Promise.resolve({ data: {} });
+  });
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <CurrencyProvider>{children}</CurrencyProvider>
+);
+
+describe('CurrencyContext.formatNative — native-only contract', () => {
+  it('formats in the supplied currency regardless of displayCurrency', async () => {
+    localStorage.setItem('displayCurrency', 'USD');
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // EUR amount formatted as EUR even though user prefers USD.
+    expect(result.current.formatNative(100, 'EUR')).toBe('€100.00');
+    expect(result.current.formatNative(100, 'GBP')).toBe('£100.00');
+    expect(result.current.formatNative(100, 'USD')).toBe('$100.00');
+  });
+
+  it('does NOT convert even if a rate is available', async () => {
+    localStorage.setItem('displayCurrency', 'EUR');
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // A USD amount must still render as $ — no automatic conversion to EUR.
+    expect(result.current.formatNative(100, 'USD')).toBe('$100.00');
+  });
+
+  it('lower-cases input currency code (defensive normalization)', async () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.formatNative(100, 'eur')).toBe('€100.00');
+  });
+
+  it('defaults to USD when no currency is provided', async () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.formatNative(100)).toBe('$100.00');
+    expect(result.current.formatNative(100, undefined)).toBe('$100.00');
+  });
+});
+
+describe('CurrencyContext.convert — kept for Portfolio use', () => {
+  it('converts USD → EUR using the loaded rate', async () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 100 USD * (0.92 EUR / 1 USD) = 92 EUR
+    expect(result.current.convert(100, 'USD', 'EUR')).toBeCloseTo(92, 5);
+  });
+
+  it('returns the same amount when no rate is available', async () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // No rate for some unknown currency → fallback to original amount.
+    expect(result.current.convert(100, 'USD', 'XYZ')).toBe(100);
+  });
+});
+
+describe('CurrencyContext.displayCurrency — Portfolio default', () => {
+  it('loads from localStorage on mount', async () => {
+    localStorage.setItem('displayCurrency', 'GBP');
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.displayCurrency).toBe('GBP'));
+  });
+
+  it('updates and persists when set', async () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.setDisplayCurrency('EUR');
+    });
+
+    expect(result.current.displayCurrency).toBe('EUR');
+    expect(localStorage.getItem('displayCurrency')).toBe('EUR');
+  });
+});

--- a/frontend/src/context/CurrencyContext.tsx
+++ b/frontend/src/context/CurrencyContext.tsx
@@ -8,17 +8,31 @@ interface AvailableCurrency {
 }
 
 interface CurrencyContextType {
+  /**
+   * The user's saved *Portfolio default* display currency. NOT a global
+   * "convert everything to this" preference. Outside the Portfolio page,
+   * monetary values are always rendered in their native currency.
+   */
   displayCurrency: string;
   setDisplayCurrency: (currency: string) => Promise<void>;
   availableCurrencies: AvailableCurrency[];
   rates: Record<string, number>;
+  /**
+   * Convert `amount` from `from` to `to` (defaults to `displayCurrency`).
+   * Used exclusively by the Portfolio page when the backend response
+   * doesn't already include a converted value. Returns the original
+   * amount unchanged when a rate is missing.
+   */
   convert: (amount: number, from: string, to?: string) => number;
   /** Formats `amount` using the supplied currency code (no conversion). */
   formatCurrency: (amount: number, currency?: string) => string;
   /**
-   * Converts `amount` from `fromCurrency` to displayCurrency and formats it.
-   * Falls back to formatting in the native currency if a rate is missing,
-   * so the displayed number is never misleading.
+   * Formats `amount` in its native `fromCurrency` with NO conversion.
+   *
+   * This is the canonical app-wide formatter for ticker prices, market caps,
+   * targets, etc. — every stock displays in the currency it trades in. The
+   * Portfolio page is the sole exception: it converts via the backend and
+   * uses {@link formatCurrency} with the chosen display currency directly.
    */
   formatNative: (amount: number, fromCurrency?: string) => string;
   loading: boolean;
@@ -116,17 +130,13 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
 
   const formatNative = useCallback(
     (amount: number, fromCurrency?: string): string => {
-      const native = (fromCurrency || displayCurrency).toUpperCase();
-      if (native === displayCurrency) {
-        return formatCurrency(amount, displayCurrency);
-      }
-      const converted = tryConvert(amount, native, displayCurrency);
-      if (converted === null) {
-        return formatCurrency(amount, native);
-      }
-      return formatCurrency(converted, displayCurrency);
+      // Native-only render. We deliberately do NOT convert to
+      // `displayCurrency` — that concept is now Portfolio-scoped. Show every
+      // ticker in the currency it actually trades in.
+      const native = (fromCurrency || 'USD').toUpperCase();
+      return formatCurrency(amount, native);
     },
-    [displayCurrency, tryConvert, formatCurrency],
+    [formatCurrency],
   );
 
   return (

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -67,14 +67,17 @@ vi.mock('../components/portfolio/EditPositionDialog', () => ({ EditPositionDialo
 vi.mock('../components/portfolio/PortfolioAiAnalyzer', () => ({ PortfolioAiAnalyzer: ({ open }: { open: boolean }) => open ? <div>AiDialog</div> : null }));
 vi.mock('../components/analyzer/FilterBar', () => ({ FilterBar: () => <div>Filter</div> }));
 vi.mock('sonner', () => ({ Toaster: () => null, toast: { success: vi.fn(), error: vi.fn() } }));
-vi.mock('lucide-react', () => ({ 
-  Search: () => <div>Search</div>, 
-  LayoutGrid: () => <div>LayoutGrid</div>, 
-  List: () => <div>List</div>, 
-  Plus: () => <div>PlusIcon</div>, 
-  X: () => <div>XIcon</div>, 
-  Bot: () => <div>Bot</div>, 
-  PieChart: () => <div>Pie</div> 
+vi.mock('lucide-react', () => ({
+  Search: () => <div>Search</div>,
+  LayoutGrid: () => <div>LayoutGrid</div>,
+  List: () => <div>List</div>,
+  Plus: () => <div>PlusIcon</div>,
+  X: () => <div>XIcon</div>,
+  Bot: () => <div>Bot</div>,
+  PieChart: () => <div>Pie</div>,
+  // Used by PortfolioCurrencySelector (mounted in the page toolbar).
+  Coins: () => <div>Coins</div>,
+  ChevronDown: () => <div>ChevronDown</div>,
 }));
 
 describe('PortfolioPage', () => {
@@ -88,10 +91,17 @@ describe('PortfolioPage', () => {
     (useAuth as Mock).mockReturnValue({ user: { uid: '1', credits_balance: 10 } });
     (useCurrency as Mock).mockReturnValue({
       displayCurrency: 'USD',
+      setDisplayCurrency: vi.fn(),
       formatCurrency: (val: number) => `$${val.toLocaleString()}`,
       formatNative: (val: number) => `$${val.toLocaleString()}`,
       convert: (amount: number) => amount,
       rates: {},
+      // Used by PortfolioCurrencySelector (mounted in the page toolbar).
+      availableCurrencies: [
+        { code: 'USD', flag: '🇺🇸' },
+        { code: 'EUR', flag: '🇪🇺' },
+      ],
+      loading: false,
     });
     (useQuery as Mock).mockReturnValue({ data: mockPositions, isLoading: false, refetch: vi.fn() });
     (useMarketSnapshots as Mock).mockReturnValue({ data: [], isLoading: false });

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { api } from '../lib/api';
 import { useAuth } from '../context/AuthContext';
 import { useCurrency } from '../context/CurrencyContext';
@@ -9,6 +9,10 @@ import { PortfolioStats } from '../components/portfolio/PortfolioStats';
 import { AddPositionDialog } from '../components/portfolio/AddPositionDialog';
 import { EditPositionDialog } from '../components/portfolio/EditPositionDialog';
 import { PortfolioAiAnalyzer } from '../components/portfolio/PortfolioAiAnalyzer';
+import {
+  PortfolioCurrencySelector,
+  PORTFOLIO_DISPLAY_NATIVE,
+} from '../components/portfolio/PortfolioCurrencySelector';
 import { FilterBar, type AnalyzerFilters } from '../components/analyzer/FilterBar';
 import { Toaster, toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
@@ -80,17 +84,44 @@ export function PortfolioPage() {
     region: [],
   });
 
-  const { displayCurrency } = useCurrency();
+  // `displayCurrency` from the context is the user's *saved* default for the
+  // Portfolio view (legacy localStorage key, no longer applied globally).
+  // We mirror it into a Portfolio-local state that also supports a NATIVE
+  // mode (= empty string), which the global context cannot represent.
+  const { displayCurrency, setDisplayCurrency } = useCurrency();
+  const [portfolioCurrency, setPortfolioCurrency] = useState<string>(
+    () => displayCurrency || 'USD',
+  );
+
+  // Keep the local pick in sync if the saved default changes (e.g. user logs
+  // in and their server-side preference loads asynchronously).
+  useEffect(() => {
+    setPortfolioCurrency((current) =>
+      current === '' ? current : displayCurrency || current,
+    );
+  }, [displayCurrency]);
+
+  const isNativeMode = portfolioCurrency === PORTFOLIO_DISPLAY_NATIVE;
 
   const { data: positions = [], isLoading, refetch } = useQuery({
-    queryKey: ['portfolio', displayCurrency],
+    queryKey: ['portfolio', portfolioCurrency],
     queryFn: async () => {
       const { data } = await api.get('/portfolio/positions', {
-        params: { displayCurrency },
+        // Omit param entirely in NATIVE mode so the backend returns each
+        // position in its own native currency without conversion.
+        params: isNativeMode ? {} : { displayCurrency: portfolioCurrency },
       });
       return data;
     },
   });
+
+  const handlePortfolioCurrencyChange = (next: string) => {
+    setPortfolioCurrency(next);
+    // Persist non-NATIVE selections as the user's default for next visit.
+    if (next !== PORTFOLIO_DISPLAY_NATIVE) {
+      void setDisplayCurrency(next);
+    }
+  };
 
 
 
@@ -129,8 +160,9 @@ export function PortfolioPage() {
     let totalRisk = 0;
     let riskCount = 0;
     let todayGain = 0;
+    let conversionUnavailable = 0;
 
-    enrichedPositions.forEach((p: PortfolioPosition & { quote?: { d?: number } }) => {
+    enrichedPositions.forEach((p: PortfolioPosition & { quote?: { d?: number }; conversion_unavailable?: boolean }) => {
       totalValue += p.current_value;
       totalCost += p.cost_basis;
 
@@ -143,6 +175,8 @@ export function PortfolioPage() {
         totalRisk += risk;
         riskCount++;
       }
+
+      if (p.conversion_unavailable) conversionUnavailable++;
     });
 
     totalGain = totalValue - totalCost;
@@ -153,7 +187,16 @@ export function PortfolioPage() {
     const previousValue = totalValue - todayGain;
     const todayGainPct = previousValue > 0 ? (todayGain / previousValue) * 100 : 0;
 
-    return { totalValue, totalGain, totalGainPct, count: positions.length, avgRisk, todayGain, todayGainPct };
+    return {
+      totalValue,
+      totalGain,
+      totalGainPct,
+      count: positions.length,
+      avgRisk,
+      todayGain,
+      todayGainPct,
+      conversionUnavailable,
+    };
   }, [enrichedPositions, positions.length]);
   const filteredPositions = useMemo(() => {
     return enrichedPositions.filter((item: unknown) => {
@@ -257,6 +300,9 @@ export function PortfolioPage() {
           positions={enrichedPositions as any[]}
           onAnalyze={() => setIsAiOpen(true)}
           credits={user?.credits_balance}
+          displayCurrency={portfolioCurrency}
+          isNativeMode={isNativeMode}
+          conversionUnavailable={stats.conversionUnavailable}
         />
 
         {/* TOOLBAR: SEARCH & FILTERS */}
@@ -285,6 +331,10 @@ export function PortfolioPage() {
 
             {/* Actions */}
             <div className="flex items-center justify-between sm:justify-end gap-2 pt-2 sm:pt-0 border-t border-border/30 sm:border-0">
+              <PortfolioCurrencySelector
+                value={portfolioCurrency}
+                onChange={handlePortfolioCurrencyChange}
+              />
               <Button
                 onClick={() => setIsAddOpen(true)}
                 className="bg-blue-600 hover:bg-blue-700 text-white gap-2 h-8 shadow-sm flex-1 sm:flex-initial"

--- a/src/modules/market-data/market-data.service.ts
+++ b/src/modules/market-data/market-data.service.ts
@@ -2250,6 +2250,9 @@ export class MarketDataService {
               symbol: t.symbol,
               name: t.name,
               exchange: t.exchange,
+              // Native trading currency — required for native-currency price
+              // rendering on analyzer rows.
+              currency: t.currency,
               logo_url: t.logo_url,
               news_sentiment: t.news_sentiment,
               news_impact_score: t.news_impact_score,

--- a/src/modules/tickers/tickers.service.spec.ts
+++ b/src/modules/tickers/tickers.service.spec.ts
@@ -311,7 +311,7 @@ describe('TickersService', () => {
       const result = await service.getAllTickers();
       expect(result).toEqual(tickers);
       expect(mockTickerRepo.find).toHaveBeenCalledWith({
-        select: ['symbol', 'name', 'exchange'],
+        select: ['symbol', 'name', 'exchange', 'currency'],
         where: { is_hidden: false },
         order: { symbol: 'ASC' },
       });

--- a/src/modules/tickers/tickers.service.ts
+++ b/src/modules/tickers/tickers.service.ts
@@ -14,6 +14,7 @@ import { TickerEntity } from './entities/ticker.entity';
 import { TickerLogoEntity } from './entities/ticker-logo.entity';
 import { TickerRequestEntity } from '../ticker-requests/entities/ticker-request.entity'; // Added
 import { PriceOhlcv } from '../market-data/entities/price-ohlcv.entity';
+import { inferCurrencyFromExchange } from './utils/exchange-currency.util';
 import { FinnhubService } from '../finnhub/finnhub.service';
 import { YahooFinanceService } from '../yahoo-finance/yahoo-finance.service';
 import { JobsService } from '../jobs/jobs.service'; // Added
@@ -174,7 +175,13 @@ export class TickersService {
       symbol: upperSymbol,
       name: profile.name || upperSymbol,
       exchange: profile.exchange || 'Unknown',
-      currency: profile.currency || 'USD',
+      // Native trading currency: trust the data provider first; fall back to
+      // exchange/symbol inference only when both Finnhub and Yahoo returned
+      // nothing (avoids defaulting EU stocks to USD during degraded windows).
+      currency:
+        profile.currency ||
+        inferCurrencyFromExchange(profile.exchange, upperSymbol) ||
+        'USD',
       country: profile.country || 'Unknown',
       ipo_date: profile.ipo,
       market_capitalization: profile.marketCapitalization,
@@ -268,7 +275,9 @@ export class TickersService {
 
   async getAllTickers(): Promise<Partial<TickerEntity>[]> {
     return this.tickerRepo.find({
-      select: ['symbol', 'name', 'exchange'],
+      // Include `currency` so callers (cron syncs, frontend list views) can
+      // render prices in their native currency without an extra round-trip.
+      select: ['symbol', 'name', 'exchange', 'currency'],
       where: { is_hidden: false },
       order: { symbol: 'ASC' },
     });
@@ -302,6 +311,7 @@ export class TickersService {
             'ticker.symbol',
             'ticker.name',
             'ticker.exchange',
+            'ticker.currency',
             'ticker.logo_url',
             'ticker.sector',
             'ticker.finnhub_industry',
@@ -643,7 +653,7 @@ export class TickersService {
 
   async getHiddenTickers(): Promise<Partial<TickerEntity>[]> {
     return this.tickerRepo.find({
-      select: ['id', 'symbol', 'name', 'exchange', 'is_hidden'],
+      select: ['id', 'symbol', 'name', 'exchange', 'currency', 'is_hidden'],
       where: { is_hidden: true },
       order: { symbol: 'ASC' },
     });
@@ -660,6 +670,7 @@ export class TickersService {
         'ticker.symbol',
         'ticker.name',
         'ticker.exchange',
+        'ticker.currency',
         'ticker.is_hidden',
         'ticker.logo_url',
       ])
@@ -790,6 +801,21 @@ export class TickersService {
           currency = 'USD';
         }
 
+        // Yahoo returned nothing — try exchange/symbol inference before
+        // giving up. Better than leaving an EU ticker on its USD default.
+        if (!currency) {
+          const inferred = inferCurrencyFromExchange(
+            ticker.exchange,
+            ticker.symbol,
+          );
+          if (inferred) {
+            this.logger.debug(
+              `Inferred currency ${inferred} for ${ticker.symbol} from exchange/suffix`,
+            );
+            currency = inferred;
+          }
+        }
+
         if (currency && currency !== ticker.currency) {
           await this.tickerRepo.update(ticker.id, { currency });
           this.logger.log(
@@ -879,7 +905,15 @@ export class TickersService {
           summary?.summaryProfile?.longName ||
           symbol,
         exchange: quote?.fullExchangeName || quote?.exchange || 'External',
-        currency: quote?.currency || 'USD',
+        // Same fallback chain as ensureTicker: provider first, then exchange
+        // inference, then USD default.
+        currency:
+          quote?.currency ||
+          inferCurrencyFromExchange(
+            quote?.fullExchangeName || quote?.exchange,
+            symbol,
+          ) ||
+          'USD',
         country: summary?.summaryProfile?.country || 'Unknown',
         ipo: null,
         marketCapitalization:

--- a/src/modules/tickers/utils/exchange-currency.util.spec.ts
+++ b/src/modules/tickers/utils/exchange-currency.util.spec.ts
@@ -1,0 +1,104 @@
+import { inferCurrencyFromExchange } from './exchange-currency.util';
+
+describe('inferCurrencyFromExchange', () => {
+  describe('symbol-suffix rules', () => {
+    it.each([
+      ['BARC.L', 'GBP'],
+      ['VOD.IL', 'GBP'],
+      ['SAP.DE', 'EUR'],
+      ['BMW.F', 'EUR'],
+      ['MC.PA', 'EUR'],
+      ['ASML.AS', 'EUR'],
+      ['STLA.MI', 'EUR'],
+      ['SAN.MC', 'EUR'],
+      ['UCB.BR', 'EUR'],
+      ['EDP.LS', 'EUR'],
+      ['NOKIA.HE', 'EUR'],
+      ['CRH.IR', 'EUR'],
+      ['EBS.VI', 'EUR'],
+      ['NESN.SW', 'CHF'],
+      ['VOLV-A.ST', 'SEK'],
+      ['EQNR.OL', 'NOK'],
+      ['NOVO-B.CO', 'DKK'],
+      ['PKN.WA', 'PLN'],
+      ['7203.T', 'JPY'],
+      ['7974.TYO', 'JPY'],
+      ['0700.HK', 'HKD'],
+      ['600519.SS', 'CNY'],
+      ['000001.SZ', 'CNY'],
+      ['005930.KS', 'KRW'],
+      ['293490.KQ', 'KRW'],
+      ['RELIANCE.BO', 'INR'],
+      ['TCS.NS', 'INR'],
+      ['BHP.AX', 'AUD'],
+      ['D05.SI', 'SGD'],
+      ['SHOP.TO', 'CAD'],
+      ['HUT.V', 'CAD'],
+      ['PETR4.SA', 'BRL'],
+      ['WALMEX.MX', 'MXN'],
+    ])('maps %s → %s by suffix', (symbol, expected) => {
+      expect(inferCurrencyFromExchange(null, symbol)).toBe(expected);
+    });
+
+    it('is case-insensitive on the suffix', () => {
+      expect(inferCurrencyFromExchange(null, 'sap.de')).toBe('EUR');
+      expect(inferCurrencyFromExchange(null, 'BARC.l')).toBe('GBP');
+    });
+  });
+
+  describe('exchange-name lookup', () => {
+    it.each([
+      ['LSE', 'GBP'],
+      ['LON', 'GBP'],
+      ['XETRA', 'EUR'],
+      ['FRA', 'EUR'],
+      ['EPA', 'EUR'],
+      ['SWX', 'CHF'],
+      ['TYO', 'JPY'],
+      ['HKEX', 'HKD'],
+      ['ASX', 'AUD'],
+      ['TSX', 'CAD'],
+      ['BMV', 'MXN'],
+      ['NYSE', 'USD'],
+      ['NASDAQ', 'USD'],
+      ['AMEX', 'USD'],
+    ])('maps exchange %s → %s', (exchange, expected) => {
+      expect(inferCurrencyFromExchange(exchange, null)).toBe(expected);
+    });
+
+    it('normalizes case and whitespace', () => {
+      expect(inferCurrencyFromExchange('  xetra  ', null)).toBe('EUR');
+      expect(inferCurrencyFromExchange('Nasdaq', null)).toBe('USD');
+    });
+  });
+
+  describe('priority: symbol suffix beats exchange', () => {
+    it('uses the symbol suffix even when exchange would yield a different currency', () => {
+      // Edge case: a German stock cross-listed and reported under generic 'OTC'.
+      // The .DE suffix is the truth.
+      expect(inferCurrencyFromExchange('OTC', 'SAP.DE')).toBe('EUR');
+    });
+  });
+
+  describe('no-match cases', () => {
+    it.each([
+      ['AAPL', null],
+      ['MSFT', null],
+      ['NVDA', null],
+      ['BRK.A', null], // dot but unknown suffix
+    ])('returns null for US-style symbol %s with no exchange hint', (symbol) => {
+      expect(inferCurrencyFromExchange(null, symbol)).toBeNull();
+    });
+
+    it('returns null for unknown exchange', () => {
+      expect(inferCurrencyFromExchange('UNKNOWN', null)).toBeNull();
+      expect(inferCurrencyFromExchange('OTC', null)).toBeNull();
+    });
+
+    it('returns null for empty / null inputs', () => {
+      expect(inferCurrencyFromExchange(null, null)).toBeNull();
+      expect(inferCurrencyFromExchange('', '')).toBeNull();
+      expect(inferCurrencyFromExchange(undefined, undefined)).toBeNull();
+    });
+  });
+});

--- a/src/modules/tickers/utils/exchange-currency.util.ts
+++ b/src/modules/tickers/utils/exchange-currency.util.ts
@@ -1,0 +1,139 @@
+/**
+ * Maps a ticker's exchange / symbol-suffix to its native trading currency.
+ *
+ * This is a SAFETY NET, not the primary source. The primary path is:
+ *   profile.currency (Finnhub) → quote.currency (Yahoo fallback) → THIS HELPER → 'USD'
+ *
+ * Only fires when both upstream APIs returned a null/empty currency, which
+ * happens during degraded windows (rate limits, outages) for tickers we'd
+ * otherwise mislabel as USD purely because of the codepath default.
+ *
+ * Returns `null` when no rule matches, so the caller can decide the
+ * ultimate default (typically 'USD'). Pure function — trivially testable
+ * and side-effect free.
+ */
+
+// Suffix → currency. Ordered by likelihood / specificity (longer prefix wins
+// where applicable; e.g. '.KS' must be tested before any single-char rule).
+// Use uppercase suffix without leading dot — we normalize before lookup.
+const SUFFIX_TO_CURRENCY: ReadonlyArray<[RegExp, string]> = [
+  // United Kingdom — London Stock Exchange
+  [/\.L$/i, 'GBP'],
+  [/\.IL$/i, 'GBP'], // pence quote — treat as GBP for display
+
+  // Eurozone — Germany / France / Netherlands / Italy / Spain / Belgium /
+  // Portugal / Finland / Ireland / Austria
+  [/\.DE$/i, 'EUR'],
+  [/\.F$/i, 'EUR'], // Frankfurt
+  [/\.PA$/i, 'EUR'],
+  [/\.AS$/i, 'EUR'],
+  [/\.MI$/i, 'EUR'],
+  [/\.MC$/i, 'EUR'],
+  [/\.BR$/i, 'EUR'],
+  [/\.LS$/i, 'EUR'],
+  [/\.HE$/i, 'EUR'],
+  [/\.IR$/i, 'EUR'],
+  [/\.VI$/i, 'EUR'],
+
+  // Other Europe
+  [/\.SW$/i, 'CHF'], // Switzerland
+  [/\.ST$/i, 'SEK'], // Stockholm
+  [/\.OL$/i, 'NOK'], // Oslo
+  [/\.CO$/i, 'DKK'], // Copenhagen
+  [/\.WA$/i, 'PLN'], // Warsaw
+
+  // Asia-Pacific
+  [/\.T$/i, 'JPY'],
+  [/\.TYO$/i, 'JPY'],
+  [/\.HK$/i, 'HKD'],
+  [/\.SS$/i, 'CNY'], // Shanghai
+  [/\.SZ$/i, 'CNY'], // Shenzhen
+  [/\.KS$/i, 'KRW'], // KOSPI
+  [/\.KQ$/i, 'KRW'], // KOSDAQ
+  [/\.BO$/i, 'INR'], // Bombay
+  [/\.NS$/i, 'INR'], // NSE India
+  [/\.AX$/i, 'AUD'],
+  [/\.SI$/i, 'SGD'],
+
+  // Americas (non-US)
+  [/\.TO$/i, 'CAD'], // Toronto
+  [/\.V$/i, 'CAD'], // TSX Venture
+  [/\.SA$/i, 'BRL'], // São Paulo
+  [/\.MX$/i, 'MXN'],
+];
+
+// Exchange-name → currency lookup for cases where the symbol is bare but the
+// `exchange` field carries the venue. Matched case-insensitively, whole word.
+const EXCHANGE_TO_CURRENCY: Readonly<Record<string, string>> = {
+  LSE: 'GBP',
+  LON: 'GBP',
+  XETRA: 'EUR',
+  FRA: 'EUR',
+  EPA: 'EUR', // Euronext Paris
+  AMS: 'EUR', // Euronext Amsterdam
+  EBR: 'EUR', // Euronext Brussels
+  ELI: 'EUR', // Euronext Lisbon
+  HEL: 'EUR',
+  ISE: 'EUR',
+  VIE: 'EUR',
+  BME: 'EUR', // Madrid
+  MIL: 'EUR',
+  SWX: 'CHF',
+  STO: 'SEK',
+  OSL: 'NOK',
+  CPH: 'DKK',
+  WAR: 'PLN',
+  TYO: 'JPY',
+  TSE: 'JPY',
+  HKEX: 'HKD',
+  SSE: 'CNY',
+  SZSE: 'CNY',
+  KRX: 'KRW',
+  BSE: 'INR',
+  NSE: 'INR',
+  ASX: 'AUD',
+  SGX: 'SGD',
+  TSX: 'CAD',
+  TSXV: 'CAD',
+  BVMF: 'BRL',
+  BMV: 'MXN',
+  // US venues — explicitly mapped so a caller that only knows the exchange
+  // (no symbol) still gets a definite answer rather than null → USD default.
+  NYSE: 'USD',
+  NASDAQ: 'USD',
+  AMEX: 'USD',
+  ARCA: 'USD',
+  BATS: 'USD',
+};
+
+/**
+ * Infer the native trading currency from a ticker's exchange / symbol.
+ *
+ * @param exchange The exchange code as returned by the data provider
+ *   (e.g. 'XETRA', 'LSE', 'NASDAQ'). May be empty/undefined.
+ * @param symbol  The ticker symbol (e.g. 'SAP.DE', 'BARC.L', 'AAPL'). May be
+ *   empty/undefined.
+ * @returns ISO 4217 currency code, or `null` when no rule matches.
+ */
+export function inferCurrencyFromExchange(
+  exchange: string | null | undefined,
+  symbol: string | null | undefined,
+): string | null {
+  // 1. Symbol-suffix rules win — they are stricter and the data provider's
+  //    `exchange` field is sometimes generic (e.g. 'OTC').
+  if (symbol) {
+    for (const [pattern, currency] of SUFFIX_TO_CURRENCY) {
+      if (pattern.test(symbol)) return currency;
+    }
+  }
+
+  // 2. Fall back to exchange-name lookup.
+  if (exchange) {
+    const normalized = exchange.trim().toUpperCase();
+    if (normalized in EXCHANGE_TO_CURRENCY) {
+      return EXCHANGE_TO_CURRENCY[normalized];
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Every stock now renders in its **NATIVE trading currency** across the entire app — NVDA in USD, SAP in EUR, BARC in GBP. The **Portfolio view is the SOLE place** where currency conversion happens: user picks a display currency from a Portfolio-local selector and positions are converted via the existing backend pipeline. The previous "global preferred display currency converts everything" model is removed.

## Why

Old behavior: when a user's preference was USD, a SAP.DE stock would render as USD-converted on Dashboard/TickerDetail/Watchlist. That hides the truth (SAP trades in EUR) and creates confusing mixed-currency comparisons on the same screen. New behavior shows the truth everywhere by default, and concentrates conversion in the one place where it's actually needed — your Portfolio totals.

## What changed

### Phase 1 — Backend gap fix

- **New util** `src/modules/tickers/utils/exchange-currency.util.ts` — pure `inferCurrencyFromExchange(exchange, symbol)`. Returns the right currency for known suffixes (\`.L → GBP\`, \`.DE/.PA/.AS/.MI/.MC/.BR/etc. → EUR\`, \`.T → JPY\`, \`.TO/.V → CAD\`, \`.AX → AUD\`, \`.SW → CHF\`, \`.HK → HKD\`, \`.SS/.SZ → CNY\`, \`.BO/.NS → INR\`, and more) plus exchange-name lookup (XETRA, LSE, NASDAQ, …). Returns \`null\` when no rule matches.
- **Wired into** \`tickers.service.ts\` at \`ensureTicker\`, Yahoo fallback path, and \`backfillTickerCurrencies\`. Chain: provider value → exchange/symbol inference → \`'USD'\`. Catches EU/UK tickers that previously defaulted to USD when Finnhub + Yahoo were both down.
- **SELECT fixes** added \`'currency'\` to \`getAllTickers\`, \`searchTickers\`, \`getHiddenTickers\`, \`searchTickersAdmin\` so frontend list views have currency without round-trips.
- **Analyzer response** at \`market-data.service:~2247\` — \`ticker\` sub-object now includes \`currency\`.

### Phase 2 — Frontend CurrencyContext: \`formatNative\` no longer converts

- \`formatNative(amount, fromCurrency)\` is now a pure native-currency formatter — formats in \`fromCurrency\` with NO conversion. Single-point change: every call site that was already passing \`ticker.currency\` (TickerCarousel, MiniTickerTile, AnalystRatingsTable, ScenarioCards, FinancialHealth, TickerDetail, …) becomes correct without being touched, because their input was always native.
- \`convert()\` and \`rates\` state kept — Portfolio uses them.
- \`displayCurrency\` state kept as the user's saved **Portfolio default** (no longer drives other pages).
- Removed the global \`CurrencySelector\` from \`Header\` — it implied app-wide effect that no longer exists. Component itself kept for backward compat.

### Phase 3 — Portfolio gets its own self-contained currency control

- New \`PortfolioCurrencySelector\` with a \`NATIVE\` option ("show each row in its own currency, don't convert") and the dynamic currency list from \`/v1/currency/available\`.
- \`PortfolioPage\` owns its currency state locally. Initialized from the user's saved default; supports NATIVE; persists non-NATIVE picks back to the user's default. NATIVE omits the \`displayCurrency\` query param so the backend returns native values.
- \`PortfolioStats\` in NATIVE mode renders totals as **"MIXED"** with a tooltip (summing across currencies is mathematically meaningless). When the backend flagged any rows as \`conversion_unavailable\`, an amber **"X of Y not converted"** pill renders near the totals.
- \`PortfolioTable\` shows a per-row amber **"FX UNAVAILABLE"** badge next to the currency chip on rows where conversion failed; values for that row stay in \`original_currency\`.

## Tests

- ✅ **56 new** \`exchange-currency.util.spec.ts\` cases (every suffix family, exchange lookups, no-match edges, normalization)
- ✅ **8 new** \`CurrencyContext.test.tsx\` specs locking the native-only contract
- ✅ Existing \`tickers.service.spec.ts\` updated for new SELECT shape
- ✅ Existing \`PortfolioPage.test.tsx\` extended with lucide-react + useCurrency mock plumbing
- ✅ Backend: 515 / 515 passing
- ✅ Frontend: 189 / 199 passing (the 10 reds are TickerDetail + MarketStatusBar suites — both broken pre-existing on main, verified by stashing my changes and re-running)

## Manual matrix to verify post-merge

| Scenario | Expected |
|---|---|
| Open SAP.DE ticker page | Price prefixed €, not $ |
| Open BARC.L | Prices prefixed £ |
| Open NVDA / AAPL | Prices prefixed $ |
| Watchlist with mixed-currency tickers | Each row in its own currency |
| Analyzer table | Same — per-row currency rendering |
| Portfolio with USD + EUR + GBP positions, display = `EUR` | Rows + totals in EUR |
| Same portfolio, display = `NATIVE` | Each row in its own currency, totals = "MIXED" |
| Force backend FX failure | Affected rows show `FX UNAVAILABLE`, totals say "X of Y not converted" |

## Out of scope

- V2 frontend (`frontend-v2/`) — experimental POC, untouched per user direction.
- Pre-existing TickerDetail / MarketStatusBar test failures — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)