### PR TITLE
Run daily candle sync hourly as stale-first batches

### DIFF
--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   schedule:
-    # Daily at Midnight UTC (Sync Candles, Watchers, Moderation)
+    # Daily at Midnight UTC (Watchers Sync, Moderation, Research cleanup)
     - cron: '0 0 * * *'
-    # Hourly (Risk/Reward Scanner, Posts Sync, Cleanup, Research-stale-2w trigger)
+    # Hourly (Candle Sync batch, Risk/Reward Scanner, Posts Sync, Cleanup)
     - cron: '0 * * * *'
     # Every 5 mins during market hours (6 AM - 9 PM UTC, Mon-Fri)
     # Used by: snapshot-sync (price tick) + market-hours-refresh (top picks, portfolios)
@@ -22,12 +22,6 @@ jobs:
     environment: prod
     if: github.event.schedule == '0 0 * * *' || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Trigger Daily Candle Sync
-        run: |
-          curl --fail-with-body --show-error -sS -X POST "${{ vars.CLOUD_RUN_URL }}/api/v1/jobs/sync-daily-candles" \
-            -H "X-Cron-Secret:${{ secrets.CRON_SECRET }}" \
-            -H "Content-Type:application/json"
-
       - name: Trigger Daily Watchers Sync
         run: |
           curl --fail-with-body --show-error -sS -X POST "${{ vars.CLOUD_RUN_URL }}/api/v1/stocktwits/jobs/sync-watchers" \
@@ -40,7 +34,7 @@ jobs:
             -H "X-Cron-Secret:${{ secrets.CRON_SECRET }}" \
             -H "Content-Type:application/json"
 
-      - name: Cleanup Old Research (>30 days)
+      - name: Cleanup Old Research (>90 days + orphaned analyses)
         run: curl -X POST ${{ vars.CLOUD_RUN_URL }}/api/v1/jobs/cleanup-old-research -H "X-Cron-Secret:${{ secrets.CRON_SECRET }}" -H "Content-Type:application/json"
 
   hourly-jobs:
@@ -48,9 +42,21 @@ jobs:
     environment: prod
     if: github.event.schedule == '0 * * * *' || github.event_name == 'workflow_dispatch'
     steps:
-      # Triggers research for tickers with risk/reward score missing or older than 14 days.
+      # Daily (1d) candle sync, split into a small stale-first batch per hour so
+      # each run stays well under the Cloud Run 5-min request timeout. Full
+      # universe coverage is reached over the course of the day (oldest 1d
+      # candle first). Previously ran once at midnight and timed out (504).
+      - name: Trigger Candle Sync (hourly stale-first batch)
+        run: |
+          curl --fail-with-body --show-error -sS -X POST "${{ vars.CLOUD_RUN_URL }}/api/v1/jobs/sync-daily-candles" \
+            -H "X-Cron-Secret:${{ secrets.CRON_SECRET }}" \
+            -H "Content-Type:application/json"
+
+      # Queues research for the most-stale tickers (never-analysed first, then
+      # oldest), rotating through the whole universe on a ~weekly cadence. Hard
+      # daily free-LLM budget caps total calls so it never hits the billed key.
       # Endpoint returns 202 immediately and runs the scan in the background.
-      - name: Trigger Risk/Reward Scanner (queues stale-research >14d)
+      - name: Trigger Risk/Reward Scanner (stale-first rotation, budget-gated)
         run: |
           curl --fail-with-body --show-error -sS -X POST "${{ vars.CLOUD_RUN_URL }}/api/v1/jobs/run-risk-reward-scanner" \
             -H "X-Cron-Secret:${{ secrets.CRON_SECRET }}" \
@@ -104,7 +110,7 @@ jobs:
     environment: prod
     if: github.event.schedule == '*/5 * * * *' || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Trigger Risk/Reward Scanner (5 tickers per run)
+      - name: Trigger Risk/Reward Scanner (stale-first batch, budget-gated)
         run: curl -X POST ${{ vars.CLOUD_RUN_URL }}/api/v1/jobs/run-risk-reward-scanner -H "X-Cron-Secret:${{ secrets.CRON_SECRET }}" -H "Content-Type:application/json"
 
       - name: Trigger Daily Digest Generation

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -54,10 +54,20 @@ export default () => {
           process.env.GEMINI_MODEL_EXTRACTION || 'gemini-3.1-flash-lite',
       },
     },
+    llm: {
+      // Hard daily cap on free-tier (primary-key) flash-lite calls. Kept below
+      // Google's 500/day free quota so background/cron research stops on its
+      // own and never escalates to the billed secondary key. DB-backed counter
+      // (llm_daily_usage) survives Cloud Run instance restarts.
+      dailyFreeLimit: parseInt(process.env.LLM_DAILY_FREE_LIMIT || '450', 10),
+    },
     riskReward: {
       enabled: process.env.RRSCORE_ENABLED !== 'false',
       cron: process.env.RRSCORE_CRON_EXPRESSION || '0 * * * *',
-      maxAgeHours: parseInt(process.env.RRSCORE_MAX_AGE_HOURS || '24', 10),
+      // Re-research cadence for the universe scan: a ticker is "due" once its
+      // latest analysis is older than this (or it has never been analysed).
+      // Defaults to 7 days ("raz za tyzden").
+      maxAgeHours: parseInt(process.env.RRSCORE_MAX_AGE_HOURS || '168', 10),
       batchSize: parseInt(process.env.RRSCORE_BATCH_SIZE || '50', 10),
       provider: process.env.RRSCORE_PROVIDER || 'gemini',
     },

--- a/src/migrations/1769640000000-CreateLlmDailyUsage.ts
+++ b/src/migrations/1769640000000-CreateLlmDailyUsage.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateLlmDailyUsage1769640000000 implements MigrationInterface {
+  name = 'CreateLlmDailyUsage1769640000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "llm_daily_usage" (
+        "usage_date" DATE PRIMARY KEY,
+        "count" INTEGER NOT NULL DEFAULT 0,
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "llm_daily_usage"`);
+  }
+}

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -68,6 +68,17 @@ export class JobsController {
     return { message: 'Cleanup completed', stats: result };
   }
 
+  @Post('cleanup-old-research')
+  @ApiOperation({
+    summary:
+      'Purge research notes older than the retention window and sweep orphaned risk analyses (Cron)',
+  })
+  @ApiResponse({ status: 200, description: 'Old research cleanup completed' })
+  async cleanupOldResearch() {
+    const result = await this.jobsService.cleanupOldResearch();
+    return { message: 'Old research cleanup completed', stats: result };
+  }
+
   @Post('sync-research/:symbol')
   @ApiOperation({
     summary: 'Reprocess research + dedupe analyst ratings for a ticker',

--- a/src/modules/jobs/jobs.module.ts
+++ b/src/modules/jobs/jobs.module.ts
@@ -10,6 +10,7 @@ import { RiskRewardModule } from '../risk-reward/risk-reward.module';
 import { ResearchModule } from '../research/research.module';
 import { StockTwitsModule } from '../stocktwits/stocktwits.module';
 import { PortfolioModule } from '../portfolio/portfolio.module';
+import { LlmModule } from '../llm/llm.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { PortfolioModule } from '../portfolio/portfolio.module';
     RiskRewardModule,
     ResearchModule,
     StockTwitsModule,
+    LlmModule,
     TypeOrmModule.forFeature([RequestQueue]),
     forwardRef(() => TickersModule),
     forwardRef(() => PortfolioModule),

--- a/src/modules/jobs/jobs.service.spec.ts
+++ b/src/modules/jobs/jobs.service.spec.ts
@@ -10,6 +10,7 @@ import { ResearchService } from '../research/research.service';
 import { StockTwitsService } from '../stocktwits/stocktwits.service';
 import { RequestQueue } from './entities/request-queue.entity';
 import { PortfolioService } from '../portfolio/portfolio.service';
+import { LlmBudgetService } from '../llm/llm-budget.service';
 
 describe('JobsService', () => {
   let service: JobsService;
@@ -17,6 +18,15 @@ describe('JobsService', () => {
   const mockRiskRewardService = {
     evaluateSymbol: jest.fn(),
     getLatestScore: jest.fn(),
+    pickStaleAnalysisTickers: jest.fn(),
+    deleteOrphanedAnalyses: jest.fn(),
+  };
+
+  const mockLlmBudgetService = {
+    getRemaining: jest.fn().mockResolvedValue(450),
+    hasBudget: jest.fn().mockResolvedValue(true),
+    record: jest.fn().mockResolvedValue(undefined),
+    getUsageToday: jest.fn().mockResolvedValue(0),
   };
 
   const mockTickersService = {
@@ -82,6 +92,7 @@ describe('JobsService', () => {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue(24) },
         },
+        { provide: LlmBudgetService, useValue: mockLlmBudgetService },
       ],
     }).compile();
 
@@ -96,32 +107,55 @@ describe('JobsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('syncDailyCandles', () => {
-    it('should iterate tickers and sync candles', async () => {
-      const tickers = [{ symbol: 'AAPL' }, { symbol: 'TSLA' }];
-      mockTickersService.getAllTickers.mockResolvedValue(tickers);
+  describe('syncDailyCandles (hourly stale-first batch)', () => {
+    it('asks market-data for the stale-first batch and syncs only those', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'TSLA' },
+        { symbol: 'MSFT' },
+      ]);
+      // Picker returns just two of the three — the batch limit in effect.
+      mockMarketDataService.pickStaleSnapshotTickers.mockResolvedValue([
+        'MSFT',
+        'AAPL',
+      ]);
       mockMarketDataService.getSnapshot.mockResolvedValue({});
 
-      await service.syncDailyCandles();
+      const result = await service.syncDailyCandles();
 
-      expect(mockTickersService.getAllTickers).toHaveBeenCalled();
+      expect(
+        mockMarketDataService.pickStaleSnapshotTickers,
+      ).toHaveBeenCalledWith(
+        ['AAPL', 'TSLA', 'MSFT'],
+        JobsService.DAILY_CANDLES_BATCH_SIZE,
+      );
       expect(mockMarketDataService.getSnapshot).toHaveBeenCalledTimes(2);
+      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledWith('MSFT');
       expect(mockMarketDataService.getSnapshot).toHaveBeenCalledWith('AAPL');
-      expect(mockMarketDataService.getSnapshot).toHaveBeenCalledWith('TSLA');
+      expect(mockMarketDataService.getSnapshot).not.toHaveBeenCalledWith(
+        'TSLA',
+      );
+      expect(mockMarketDataService.syncTickerHistory).toHaveBeenCalledTimes(2);
+      expect(result).toMatchObject({ processed: 2, failed: 0, batchSize: 2 });
     });
 
-    it('should handle errors gracefully for individual symbols', async () => {
-      const tickers = [{ symbol: 'AAPL' }, { symbol: 'FAIL' }];
-      mockTickersService.getAllTickers.mockResolvedValue(tickers);
-      mockMarketDataService.getSnapshot.mockResolvedValueOnce({});
-      mockMarketDataService.getSnapshot.mockRejectedValueOnce(
-        new Error('Sync failed'),
-      );
+    it('counts per-ticker errors without aborting the rest of the batch', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'FAIL' },
+      ]);
+      mockMarketDataService.pickStaleSnapshotTickers.mockResolvedValue([
+        'AAPL',
+        'FAIL',
+      ]);
+      mockMarketDataService.getSnapshot
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Sync failed'));
 
-      await service.syncDailyCandles();
+      const result = await service.syncDailyCandles();
 
       expect(mockMarketDataService.getSnapshot).toHaveBeenCalledTimes(2);
-      // Should not throw
+      expect(result).toMatchObject({ processed: 1, failed: 1, batchSize: 2 });
     });
 
     it('should handle global errors', async () => {
@@ -131,10 +165,15 @@ describe('JobsService', () => {
       await expect(service.syncDailyCandles()).rejects.toThrow('Global fail');
     });
 
-    it('should skip tickers without symbol', async () => {
-      const tickers = [{ no_symbol: '?' }];
-      mockTickersService.getAllTickers.mockResolvedValue(tickers);
+    it('drops tickers without a symbol before picking the batch', async () => {
+      mockTickersService.getAllTickers.mockResolvedValue([{ no_symbol: '?' }]);
+      mockMarketDataService.pickStaleSnapshotTickers.mockResolvedValue([]);
+
       await service.syncDailyCandles();
+
+      expect(
+        mockMarketDataService.pickStaleSnapshotTickers,
+      ).toHaveBeenCalledWith([], JobsService.DAILY_CANDLES_BATCH_SIZE);
       expect(mockMarketDataService.getSnapshot).not.toHaveBeenCalled();
     });
   });
@@ -255,7 +294,7 @@ describe('JobsService', () => {
   });
 
   describe('runRiskRewardScanner', () => {
-    it('should queue research for tickers with stale or missing analysis', async () => {
+    it('queues a cron-tier ticket for each due (stale-first) ticker within budget', async () => {
       const sleepSpy = jest
         .spyOn(global, 'setTimeout')
         // Resolve immediately to keep the test fast
@@ -264,20 +303,81 @@ describe('JobsService', () => {
           return {} as NodeJS.Timeout;
         });
 
-      const tickers = [{ symbol: 'AAPL' }];
-      mockTickersService.getAllTickers.mockResolvedValue(tickers);
-      mockRiskRewardService.getLatestScore.mockResolvedValue(null);
+      mockLlmBudgetService.getRemaining.mockResolvedValue(450);
+      mockLlmBudgetService.hasBudget.mockResolvedValue(true);
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'TSLA' },
+      ]);
+      // Picker decides who is due (oldest/never-analysed first).
+      mockRiskRewardService.pickStaleAnalysisTickers.mockResolvedValue(['AAPL']);
       mockResearchService.createResearchTicket.mockResolvedValue({
         id: 'note-1',
       });
       mockResearchService.processTicket.mockResolvedValue(undefined);
 
-      await service.runRiskRewardScanner();
+      const result = await service.runRiskRewardScanner();
 
       expect(mockTickersService.getAllTickers).toHaveBeenCalled();
-      expect(mockRiskRewardService.getLatestScore).toHaveBeenCalledWith('AAPL');
-      expect(mockResearchService.createResearchTicket).toHaveBeenCalled();
+      expect(
+        mockRiskRewardService.pickStaleAnalysisTickers,
+      ).toHaveBeenCalledWith(['AAPL', 'TSLA'], expect.any(Number), expect.any(Number));
+      expect(mockResearchService.createResearchTicket).toHaveBeenCalledWith(
+        null,
+        ['AAPL'],
+        expect.any(String),
+        'gemini',
+        'cron',
+      );
       expect(mockResearchService.processTicket).toHaveBeenCalledWith('note-1');
+      expect(result).toMatchObject({ processed: 1, errors: 0, due: 1 });
+
+      sleepSpy.mockRestore();
+    });
+
+    it('skips the whole scan when the daily LLM budget is exhausted', async () => {
+      mockLlmBudgetService.getRemaining.mockResolvedValue(0);
+      mockTickersService.getAllTickers.mockResolvedValue([{ symbol: 'AAPL' }]);
+
+      const result = await service.runRiskRewardScanner();
+
+      expect(result).toMatchObject({ budgetExhausted: true, processed: 0 });
+      expect(
+        mockRiskRewardService.pickStaleAnalysisTickers,
+      ).not.toHaveBeenCalled();
+      expect(mockResearchService.createResearchTicket).not.toHaveBeenCalled();
+    });
+
+    it('stops early when the budget drains mid-scan', async () => {
+      const sleepSpy = jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation((callback: any) => {
+          callback();
+          return {} as NodeJS.Timeout;
+        });
+
+      mockLlmBudgetService.getRemaining.mockResolvedValue(450);
+      // Budget available for the first ticket, gone before the second.
+      mockLlmBudgetService.hasBudget
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { symbol: 'AAPL' },
+        { symbol: 'MSFT' },
+      ]);
+      mockRiskRewardService.pickStaleAnalysisTickers.mockResolvedValue([
+        'AAPL',
+        'MSFT',
+      ]);
+      mockResearchService.createResearchTicket.mockResolvedValue({
+        id: 'note-1',
+      });
+      mockResearchService.processTicket.mockResolvedValue(undefined);
+
+      const result = await service.runRiskRewardScanner();
+
+      expect(mockResearchService.createResearchTicket).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({ processed: 1, due: 2 });
 
       sleepSpy.mockRestore();
     });

--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -8,6 +8,7 @@ import { MarketStatusService } from '../market-data/market-status.service';
 import { ResearchService } from '../research/research.service';
 import { StockTwitsService } from '../stocktwits/stocktwits.service';
 import { PortfolioService } from '../portfolio/portfolio.service';
+import { LlmBudgetService } from '../llm/llm-budget.service';
 import {
   RequestQueue,
   RequestStatus,
@@ -36,6 +37,7 @@ export class JobsService {
     @Inject(forwardRef(() => PortfolioService))
     private readonly portfolioService: PortfolioService,
     private readonly configService: ConfigService,
+    private readonly llmBudgetService: LlmBudgetService,
   ) {}
 
   async cleanupStuckResearch() {
@@ -99,72 +101,68 @@ export class JobsService {
     }
   }
 
-  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  @Cron(CronExpression.EVERY_HOUR)
   private async syncDailyCandlesCron() {
-    if (!this.isDevMode) return; // Production uses GitHub Actions
+    if (!this.isDevMode) return; // Production uses GitHub Actions (hourly)
     await this.syncDailyCandles();
   }
 
-  async syncDailyCandles() {
-    this.logger.log('Starting sequential batch candle sync...');
-    try {
-      const tickers = await this.tickersService.getAllTickers();
-      const BATCH_SIZE = 25;
-      const MAX_BATCHES = 5; // Process 5 batches per run (125 tickers max)
+  /**
+   * Batch size for the hourly candle sync. Sized so a single run finishes well
+   * inside the Cloud Run 5-min request timeout. The hourly cron rotates through
+   * all tickers across multiple runs via DB-driven staleness (oldest 1d candle
+   * first), so full universe coverage is reached over the course of the day.
+   */
+  static readonly DAILY_CANDLES_BATCH_SIZE = 20;
 
-      const totalBatches = Math.min(
-        Math.ceil(tickers.length / BATCH_SIZE),
-        MAX_BATCHES,
+  /**
+   * Syncs daily (1d) candles for a small, stale-first batch of tickers.
+   *
+   * Runs hourly: each run picks the N tickers whose latest 1d candle is oldest
+   * (or missing), refreshes their snapshot and backfills history. Keeping the
+   * batch small means a single run stays far under the Cloud Run request budget
+   * (the previous full-universe sync exceeded the 5-min timeout → 504), while
+   * stale-first ordering rotates coverage across the whole universe over a day.
+   */
+  async syncDailyCandles() {
+    this.logger.log('Starting hourly stale-first candle sync...');
+    try {
+      const allTickers = await this.tickersService.getAllTickers();
+      const candidates = allTickers.filter(
+        (t): t is typeof t & { symbol: string } => !!t.symbol,
       );
+
+      const batchSize = JobsService.DAILY_CANDLES_BATCH_SIZE;
+      const staleSymbols =
+        await this.marketDataService.pickStaleSnapshotTickers(
+          candidates.map((t) => t.symbol),
+          batchSize,
+        );
 
       this.logger.log(
-        `Processing ${totalBatches} batches of ${BATCH_SIZE} tickers (${totalBatches * BATCH_SIZE} total)`,
+        `Candle sync batch (${staleSymbols.length}/${candidates.length}, stale-first): ${staleSymbols.join(', ')}`,
       );
 
-      let totalProcessed = 0;
-      let totalFailed = 0;
+      let processed = 0;
+      let failed = 0;
 
-      for (let batchNum = 0; batchNum < totalBatches; batchNum++) {
-        const startIdx = batchNum * BATCH_SIZE;
-        const batch = tickers.slice(startIdx, startIdx + BATCH_SIZE);
-
-        this.logger.log(
-          `Processing batch ${batchNum + 1}/${totalBatches} (tickers ${startIdx}-${startIdx + batch.length - 1})`,
-        );
-
-        let batchProcessed = 0;
-        let batchFailed = 0;
-
-        for (const ticker of batch) {
-          if (!ticker.symbol) continue;
-          try {
-            await this.marketDataService.getSnapshot(ticker.symbol);
-            await this.marketDataService.syncTickerHistory(ticker.symbol, 5);
-            batchProcessed++;
-          } catch (err: any) {
-            batchFailed++;
-            this.logger.error(`Failed ${ticker.symbol}: ${err.message}`);
-          }
+      for (const symbol of staleSymbols) {
+        try {
+          await this.marketDataService.getSnapshot(symbol);
+          await this.marketDataService.syncTickerHistory(symbol, 5);
+          processed++;
+        } catch (err: any) {
+          failed++;
+          this.logger.error(`Failed ${symbol}: ${err.message}`);
         }
-
-        totalProcessed += batchProcessed;
-        totalFailed += batchFailed;
-
-        this.logger.log(
-          `Batch ${batchNum + 1} complete. Processed: ${batchProcessed}, Failed: ${batchFailed}`,
-        );
       }
 
       this.logger.log(
-        `All batches complete. Total Processed: ${totalProcessed}, Total Failed: ${totalFailed}`,
+        `Candle sync complete. Processed: ${processed}, Failed: ${failed}, Batch: ${staleSymbols.length}`,
       );
-      return {
-        processed: totalProcessed,
-        failed: totalFailed,
-        batches: totalBatches,
-      };
+      return { processed, failed, batchSize: staleSymbols.length };
     } catch (e) {
-      this.logger.error('Daily candle sync failed globally', e);
+      this.logger.error('Candle sync failed globally', e);
       throw e;
     }
   }
@@ -280,67 +278,86 @@ export class JobsService {
     await this.runRiskRewardScanner();
   }
 
+  /**
+   * Max tickers queued per scanner run. Small so each run stays light; the
+   * stale-first rotation + frequent cron schedule cover the whole universe
+   * over time, and the daily LLM budget is the hard ceiling on total work.
+   */
+  static readonly RISK_SCANNER_BATCH_SIZE = 5;
+
+  /**
+   * Approx. free-tier flash-lite calls one research ticket consumes (the main
+   * cron-tier research call + the financial-extraction call). Used to size the
+   * batch against the remaining daily budget so a run never starts work it
+   * can't finish on the free key.
+   */
+  static readonly RISK_SCANNER_CALLS_PER_TICKET = 2;
+
   async runRiskRewardScanner() {
     const maxAgeHours =
-      this.configService.get<number>('riskReward.maxAgeHours') || 24;
+      this.configService.get<number>('riskReward.maxAgeHours') || 168;
+    const stalenessMs = maxAgeHours * 60 * 60 * 1000;
+    const perTicket = JobsService.RISK_SCANNER_CALLS_PER_TICKET;
+
     this.logger.log(
       `Starting risk/reward scanner (cron tier, staleness: ${maxAgeHours}h)...`,
     );
     try {
-      const tickers = await this.tickersService.getAllTickers();
-      // Frequent + small: 5 tickers per run × every 5 min
-      // = ~25s work per run, completes 150 stocks in ~2.5h
-      const BATCH_SIZE = 5;
-      const MAX_BATCHES = 1;
-      const DELAY_MS = 4500; // ~13 RPM to stay safely under 15 RPM
+      // Hard daily budget gate: protect the free flash-lite quota and never
+      // let cron research escalate to the billed key.
+      const remaining = await this.llmBudgetService.getRemaining();
+      if (remaining < perTicket) {
+        this.logger.warn(
+          `Daily free LLM budget exhausted (remaining: ${remaining}). Skipping scan.`,
+        );
+        return { processed: 0, errors: 0, due: 0, budgetExhausted: true };
+      }
 
-      const totalBatches = Math.min(
-        Math.ceil(tickers.length / BATCH_SIZE),
-        MAX_BATCHES,
+      const allTickers = await this.tickersService.getAllTickers();
+      const symbols = allTickers
+        .map((t) => t.symbol)
+        .filter((s): s is string => !!s);
+
+      // Size this run to the smaller of the fixed batch and what the remaining
+      // budget can afford.
+      const budgetCap = Math.floor(remaining / perTicket);
+      const limit = Math.min(JobsService.RISK_SCANNER_BATCH_SIZE, budgetCap);
+
+      // Stale-first rotation (never-analysed first, then oldest). Replaces the
+      // old slice(0, 5) window that only ever touched the first few tickers
+      // alphabetically and never rotated, so unwatched tickers never got
+      // scanned. Now coverage advances every run.
+      const dueSymbols = await this.riskRewardService.pickStaleAnalysisTickers(
+        symbols,
+        limit,
+        stalenessMs,
       );
 
       this.logger.log(
-        `Processing ${totalBatches} batches of ${BATCH_SIZE} tickers (${totalBatches * BATCH_SIZE} max)`,
+        `Scanner batch (${dueSymbols.length} due / ${symbols.length} total, budget remaining: ${remaining}): ${dueSymbols.join(', ')}`,
       );
 
-      let totalProcessed = 0;
-      let totalSkipped = 0;
-      const stalenessMs = maxAgeHours * 60 * 60 * 1000;
+      const DELAY_MS = 4500; // ~13 RPM, safely under the 15 RPM free limit
+      let processed = 0;
+      let errors = 0;
 
-      for (let batchNum = 0; batchNum < totalBatches; batchNum++) {
-        const startIdx = batchNum * BATCH_SIZE;
-        const batch = tickers.slice(startIdx, startIdx + BATCH_SIZE);
+      for (const symbol of dueSymbols) {
+        // Re-check before each ticket — the free pool is shared with other
+        // jobs and interactive users, so it can drain mid-run.
+        if (!(await this.llmBudgetService.hasBudget(perTicket))) {
+          this.logger.warn(
+            'Daily free LLM budget reached mid-scan. Stopping early.',
+          );
+          break;
+        }
 
-        this.logger.log(
-          `Processing batch ${batchNum + 1}/${totalBatches} (tickers ${startIdx}-${startIdx + batch.length - 1})`,
-        );
+        try {
+          this.logger.log(`Queueing Cron-Tier Scan for ${symbol}...`);
 
-        let batchProcessed = 0;
-        let batchSkipped = 0;
-
-        for (const ticker of batch) {
-          if (!ticker.symbol) continue;
-          const symbol = ticker.symbol;
-
-          try {
-            const existingAnalysis =
-              await this.riskRewardService.getLatestScore(symbol);
-
-            const isStale =
-              !existingAnalysis ||
-              Date.now() - existingAnalysis.created_at.getTime() > stalenessMs;
-
-            if (!isStale) {
-              batchSkipped++;
-              continue;
-            }
-
-            this.logger.log(`Queueing Cron-Tier Scan for ${symbol}...`);
-
-            const note = await this.researchService.createResearchTicket(
-              null,
-              [symbol],
-              `Analyze the risk/reward profile for ${symbol} based on recent price action (OHLCV) and key fundamentals.
+          const note = await this.researchService.createResearchTicket(
+            null,
+            [symbol],
+            `Analyze the risk/reward profile for ${symbol} based on recent price action (OHLCV) and key fundamentals.
 
       CRITICAL INSTRUCTION:
       You MUST act as a data gatherer.
@@ -355,36 +372,25 @@ export class JobsService {
 
       Then provide a Risk/Reward Score (0-10) and a succinct summary.
       `,
-              'gemini',
-              'cron',
-            );
+            'gemini',
+            'cron',
+          );
 
-            await this.researchService.processTicket(note.id);
-            batchProcessed++;
+          await this.researchService.processTicket(note.id);
+          processed++;
 
-            // Rate limit: 15 RPM on free tier = ~4.5s between calls
-            await new Promise((r) => setTimeout(r, DELAY_MS));
-          } catch (err) {
-            this.logger.error(`Scanner failed for ${symbol}: ${err.message}`);
-          }
+          // Rate limit: 15 RPM on free tier = ~4.5s between calls
+          await new Promise((r) => setTimeout(r, DELAY_MS));
+        } catch (err) {
+          errors++;
+          this.logger.error(`Scanner failed for ${symbol}: ${err.message}`);
         }
-
-        totalProcessed += batchProcessed;
-        totalSkipped += batchSkipped;
-
-        this.logger.log(
-          `Batch ${batchNum + 1} complete. Processed: ${batchProcessed}, Skipped: ${batchSkipped}`,
-        );
       }
 
       this.logger.log(
-        `All batches complete. Total Processed: ${totalProcessed}, Total Skipped: ${totalSkipped}`,
+        `Scan complete. Processed: ${processed}, Errors: ${errors}, Due this run: ${dueSymbols.length}`,
       );
-      return {
-        processed: totalProcessed,
-        skipped: totalSkipped,
-        batches: totalBatches,
-      };
+      return { processed, errors, due: dueSymbols.length };
     } catch (e) {
       this.logger.error('Risk/Reward Scanner failed globally', e);
       throw e;
@@ -551,7 +557,10 @@ export class JobsService {
     }
   }
 
-  // --- RESEARCH RETENTION CLEANUP (30 days) ---
+  // --- RESEARCH RETENTION CLEANUP (90 days) ---
+
+  /** Research notes older than this are purged. */
+  static readonly RESEARCH_RETENTION_DAYS = 90;
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)
   private async cleanupOldResearchCron() {
@@ -560,11 +569,19 @@ export class JobsService {
   }
 
   async cleanupOldResearch() {
-    this.logger.log('Starting old research cleanup (>30 days)...');
+    const retentionDays = JobsService.RESEARCH_RETENTION_DAYS;
+    this.logger.log(`Starting old research cleanup (>${retentionDays} days)...`);
     try {
-      const deleted = await this.researchService.deleteOldResearch(30);
-      this.logger.log(`Research cleanup complete. Deleted: ${deleted}`);
-      return { deleted };
+      const deleted =
+        await this.researchService.deleteOldResearch(retentionDays);
+      // Purging notes can leave risk analyses pointing at deleted notes —
+      // sweep those orphans after the notes are gone.
+      const orphansDeleted =
+        await this.riskRewardService.deleteOrphanedAnalyses();
+      this.logger.log(
+        `Research cleanup complete. Notes deleted: ${deleted}, orphaned analyses deleted: ${orphansDeleted}`,
+      );
+      return { deleted, orphansDeleted };
     } catch (e) {
       this.logger.error('Research cleanup failed', e);
       throw e;

--- a/src/modules/llm/entities/llm-daily-usage.entity.ts
+++ b/src/modules/llm/entities/llm-daily-usage.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryColumn, Column, UpdateDateColumn } from 'typeorm';
+
+/**
+ * One row per UTC calendar day, tracking how many free-tier (primary-key)
+ * Gemini flash-lite calls have been made. Backs the hard daily budget that
+ * stops background/cron research before it exhausts the free quota and
+ * escalates to the billed secondary key. DB-backed so the cap survives
+ * Cloud Run instance restarts.
+ */
+@Entity('llm_daily_usage')
+export class LlmDailyUsage {
+  // UTC calendar date, formatted 'YYYY-MM-DD'.
+  @PrimaryColumn({ type: 'date' })
+  usage_date: string;
+
+  // Free-tier flash-lite calls consumed on this date.
+  @Column({ type: 'integer', default: 0 })
+  count: number;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updated_at: Date;
+}

--- a/src/modules/llm/llm-budget.service.spec.ts
+++ b/src/modules/llm/llm-budget.service.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { LlmBudgetService } from './llm-budget.service';
+import { LlmDailyUsage } from './entities/llm-daily-usage.entity';
+
+describe('LlmBudgetService', () => {
+  let service: LlmBudgetService;
+
+  const mockRepo = {
+    findOne: jest.fn(),
+    query: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockConfig = {
+    get: jest.fn().mockReturnValue(450),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LlmBudgetService,
+        { provide: getRepositoryToken(LlmDailyUsage), useValue: mockRepo },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get<LlmBudgetService>(LlmBudgetService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('reports remaining budget as limit minus usage', async () => {
+    mockRepo.findOne.mockResolvedValue({ count: 100 });
+    expect(await service.getRemaining()).toBe(350);
+  });
+
+  it('treats a missing row as zero usage', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+    expect(await service.getUsageToday()).toBe(0);
+    expect(await service.getRemaining()).toBe(450);
+  });
+
+  it('never returns negative remaining', async () => {
+    mockRepo.findOne.mockResolvedValue({ count: 600 });
+    expect(await service.getRemaining()).toBe(0);
+  });
+
+  it('hasBudget reflects whether enough calls remain', async () => {
+    mockRepo.findOne.mockResolvedValue({ count: 449 });
+    expect(await service.hasBudget(1)).toBe(true);
+    expect(await service.hasBudget(2)).toBe(false);
+  });
+
+  it('record() upserts the daily counter and never throws on db error', async () => {
+    mockRepo.query.mockRejectedValueOnce(new Error('db down'));
+    await expect(service.record(1)).resolves.toBeUndefined();
+    expect(mockRepo.query).toHaveBeenCalled();
+  });
+
+  it('record() is a no-op for non-positive counts', async () => {
+    await service.record(0);
+    expect(mockRepo.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/llm/llm-budget.service.ts
+++ b/src/modules/llm/llm-budget.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LlmDailyUsage } from './entities/llm-daily-usage.entity';
+
+/**
+ * Hard, DB-backed daily budget for free-tier (primary-key) Gemini flash-lite
+ * calls. Background/cron research checks this before queueing work and stops
+ * once the cap is reached, so it never exhausts the free quota and escalates
+ * to the billed secondary key. DB-backed so the cap survives instance restarts
+ * and is shared across concurrent Cloud Run instances.
+ */
+@Injectable()
+export class LlmBudgetService {
+  private readonly logger = new Logger(LlmBudgetService.name);
+
+  constructor(
+    @InjectRepository(LlmDailyUsage)
+    private readonly usageRepo: Repository<LlmDailyUsage>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Daily cap on free-tier flash-lite calls. Kept safely below Google's real
+   * 500/day free quota so background work stops with margin to spare (the
+   * margin also absorbs the few hours of skew between UTC day boundaries and
+   * Google's Pacific quota reset).
+   */
+  getDailyLimit(): number {
+    return this.configService.get<number>('llm.dailyFreeLimit') ?? 450;
+  }
+
+  private todayKey(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  /**
+   * Atomically records `count` consumed free-tier calls for today.
+   * Accounting must never break an in-flight LLM call, so failures are
+   * logged and swallowed rather than thrown.
+   */
+  async record(count = 1): Promise<void> {
+    if (count <= 0) return;
+    try {
+      await this.usageRepo.query(
+        `INSERT INTO "llm_daily_usage" ("usage_date", "count", "updated_at")
+         VALUES ($1, $2, NOW())
+         ON CONFLICT ("usage_date")
+         DO UPDATE SET "count" = "llm_daily_usage"."count" + EXCLUDED."count",
+                       "updated_at" = NOW()`,
+        [this.todayKey(), count],
+      );
+    } catch (err: any) {
+      this.logger.warn(`Failed to record LLM usage: ${err.message}`);
+    }
+  }
+
+  /** Free-tier calls already consumed today. */
+  async getUsageToday(): Promise<number> {
+    const row = await this.usageRepo.findOne({
+      where: { usage_date: this.todayKey() },
+    });
+    return row?.count ?? 0;
+  }
+
+  /** Free-tier calls still available today (never negative). */
+  async getRemaining(): Promise<number> {
+    const used = await this.getUsageToday();
+    return Math.max(0, this.getDailyLimit() - used);
+  }
+
+  /** Whether at least `need` free-tier calls remain today. */
+  async hasBudget(need = 1): Promise<boolean> {
+    return (await this.getRemaining()) >= need;
+  }
+}

--- a/src/modules/llm/llm.module.ts
+++ b/src/modules/llm/llm.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { LlmService } from './llm.service';
+import { LlmBudgetService } from './llm-budget.service';
+import { LlmDailyUsage } from './entities/llm-daily-usage.entity';
 import { OpenAiProvider } from './providers/openai.provider';
 import { GeminiProvider } from './providers/gemini.provider';
 
 @Module({
-  imports: [ConfigModule],
-  providers: [LlmService, OpenAiProvider, GeminiProvider],
-  exports: [LlmService],
+  imports: [ConfigModule, TypeOrmModule.forFeature([LlmDailyUsage])],
+  providers: [LlmService, LlmBudgetService, OpenAiProvider, GeminiProvider],
+  exports: [LlmService, LlmBudgetService],
 })
 export class LlmModule {}

--- a/src/modules/llm/llm.types.ts
+++ b/src/modules/llm/llm.types.ts
@@ -18,6 +18,13 @@ export interface ResearchPrompt {
   quality?: QualityTier;
   provider?: 'openai' | 'gemini' | 'ensemble';
   apiKey?: string;
+  /**
+   * When true (implied for `quality: 'cron'`), the call must stay on the free
+   * primary key: on a 429 it falls back across free models but NEVER escalates
+   * to the billed secondary key. Used by background/cron research to protect
+   * the free quota and guarantee zero billed spend.
+   */
+  freeOnly?: boolean;
 }
 
 export interface ResearchResult {

--- a/src/modules/llm/providers/gemini.provider.spec.ts
+++ b/src/modules/llm/providers/gemini.provider.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { GeminiProvider } from './gemini.provider';
+import { LlmBudgetService } from '../llm-budget.service';
 import { ResearchPrompt } from '../llm.types';
 import { GoogleGenAI } from '@google/genai';
 
@@ -44,6 +45,10 @@ describe('GeminiProvider', () => {
               return null;
             }),
           },
+        },
+        {
+          provide: LlmBudgetService,
+          useValue: { record: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/src/modules/llm/providers/gemini.provider.ts
+++ b/src/modules/llm/providers/gemini.provider.ts
@@ -7,6 +7,7 @@ import {
   GenerateContentConfig,
 } from '@google/genai'; // NEW SDK
 import { ILlmProvider, ResearchPrompt, ResearchResult } from '../llm.types';
+import { LlmBudgetService } from '../llm-budget.service';
 
 @Injectable()
 export class GeminiProvider implements ILlmProvider {
@@ -30,7 +31,10 @@ export class GeminiProvider implements ILlmProvider {
     'gemma-4-31b-it',
   ]);
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly budgetService: LlmBudgetService,
+  ) {
     const apiKey = this.configService.get<string>('gemini.apiKey');
     if (apiKey) {
       this.client = new GoogleGenAI({ apiKey });
@@ -142,6 +146,9 @@ export class GeminiProvider implements ILlmProvider {
     const secondaryApiKey = this.configService.get<string>(
       'gemini.secondaryApiKey',
     );
+    // Cron / background research must stay on the free key: never escalate to
+    // the billed secondary key on a 429.
+    const freeOnly = prompt.freeOnly === true || prompt.quality === 'cron';
     let hasSwitchedToSecondary = false;
     let activeApiKey = apiKey;
     let activeClient = client;
@@ -193,6 +200,13 @@ export class GeminiProvider implements ILlmProvider {
           (p) => p.thought,
         );
 
+        // Count successful free-tier (primary key) flash-lite calls against
+        // the hard daily budget. Gemma (separate quota) and billed secondary
+        // calls are intentionally excluded.
+        if (!hasSwitchedToSecondary && freeModels.includes(currentModel)) {
+          await this.budgetService.record(1);
+        }
+
         return {
           provider: 'gemini',
           models: [currentModel],
@@ -226,6 +240,16 @@ export class GeminiProvider implements ILlmProvider {
             );
             currentModel = nextFreeModel;
             continue;
+          }
+
+          // Free-only (cron/background) work must NEVER touch the billed
+          // secondary key. Once free models are exhausted, fail fast and let
+          // the daily budget gate hold the cron back until quota resets.
+          if (freeOnly && !hasSwitchedToSecondary) {
+            this.logger.warn(
+              `Gemini 429 for ${currentModel} (free-only). Free models exhausted — not escalating to the billed key.`,
+            );
+            throw err;
           }
 
           // 2. If no more free models or already on secondary, check if we can switch from Primary -> Secondary

--- a/src/modules/risk-reward/risk-reward.service.ts
+++ b/src/modules/risk-reward/risk-reward.service.ts
@@ -304,6 +304,100 @@ export class RiskRewardService {
     });
   }
 
+  /**
+   * Picks the `limit` most-stale tickers that are "due" for (re)analysis,
+   * never-researched first, then oldest analysis first. A ticker is due when
+   * it has no analysis at all, or its latest analysis is older than `maxAgeMs`.
+   *
+   * This drives the universe scanner's stale-first rotation: instead of always
+   * scanning the same alphabetical window, every run advances to whatever is
+   * most overdue, so every ticker (watchlisted or not) gets covered on a
+   * rolling cadence. The whole decision is a single DB query — no per-ticker
+   * snapshot fetches.
+   */
+  async pickStaleAnalysisTickers(
+    candidateSymbols: string[],
+    limit: number,
+    maxAgeMs: number,
+  ): Promise<string[]> {
+    if (candidateSymbols.length === 0 || limit <= 0) return [];
+
+    const rows: { symbol: string; last_at: string | null }[] =
+      await this.analysisRepo
+        .createQueryBuilder('a')
+        .innerJoin('a.ticker', 't')
+        .select('t.symbol', 'symbol')
+        .addSelect('MAX(a.created_at)', 'last_at')
+        .where('t.symbol IN (:...symbols)', { symbols: candidateSymbols })
+        .groupBy('t.symbol')
+        .getRawMany();
+
+    const lastAtBySymbol = new Map<string, number>();
+    for (const r of rows) {
+      if (r.last_at) {
+        lastAtBySymbol.set(r.symbol, new Date(r.last_at).getTime());
+      }
+    }
+
+    const now = Date.now();
+    const due = candidateSymbols.filter((s) => {
+      const ts = lastAtBySymbol.get(s);
+      return ts === undefined || now - ts > maxAgeMs; // never analysed or stale
+    });
+
+    return due
+      .sort((a, b) => {
+        const aTs = lastAtBySymbol.get(a);
+        const bTs = lastAtBySymbol.get(b);
+        if (aTs === undefined && bTs === undefined) return a.localeCompare(b);
+        if (aTs === undefined) return -1; // never researched → highest priority
+        if (bTs === undefined) return 1;
+        return aTs - bTs; // oldest analysis first
+      })
+      .slice(0, limit);
+  }
+
+  /**
+   * Deletes risk analyses whose linked research note no longer exists
+   * (`research_note_id` is set but points to a purged note). Run after the
+   * research-retention cleanup so the scores left dangling by deleted notes
+   * don't accumulate.
+   *
+   * `risk_analyses.research_note_id` stores `research_notes.id` (a bigint) as
+   * text. Child rows (scenarios / qualitative factors / catalysts) are deleted
+   * explicitly inside a transaction rather than relying on a DB-level
+   * ON DELETE CASCADE, since those tables were created via schema sync (no
+   * migration) and their cascade behaviour can't be assumed.
+   */
+  async deleteOrphanedAnalyses(): Promise<number> {
+    const orphanWhere = `research_note_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM research_notes rn WHERE CAST(rn.id AS TEXT) = risk_analyses.research_note_id)`;
+
+    return this.analysisRepo.manager.transaction(async (mgr) => {
+      const countRows: { count: string }[] = await mgr.query(
+        `SELECT COUNT(*)::int AS count FROM risk_analyses WHERE ${orphanWhere}`,
+      );
+      const count = countRows[0]?.count ? Number(countRows[0].count) : 0;
+      if (count === 0) return 0;
+
+      const childSelect = `SELECT id FROM risk_analyses WHERE ${orphanWhere}`;
+      await mgr.query(
+        `DELETE FROM risk_scenarios WHERE analysis_id IN (${childSelect})`,
+      );
+      await mgr.query(
+        `DELETE FROM risk_qualitative_factors WHERE analysis_id IN (${childSelect})`,
+      );
+      await mgr.query(
+        `DELETE FROM risk_catalysts WHERE analysis_id IN (${childSelect})`,
+      );
+      await mgr.query(`DELETE FROM risk_analyses WHERE ${orphanWhere}`);
+
+      this.logger.log(
+        `Deleted ${count} orphaned risk analyses (and their child rows).`,
+      );
+      return count;
+    });
+  }
+
   // Called by ResearchService after a Deep Research Note is generated
   async evaluateFromResearch(note: any): Promise<RiskAnalysis | null> {
     if (!note || !note.answer_markdown) return null;


### PR DESCRIPTION
Change the daily candle sync to run hourly as a small, stale-first batch to avoid Cloud Run 5-minute timeouts. Added DAILY_CANDLES_BATCH_SIZE (20) and switched the JobsService cron to EVERY_HOUR; syncDailyCandles now filters tickers without symbols, asks marketDataService.pickStaleSnapshotTickers for a limited stale-first list, processes only those symbols, and returns processed/failed/batchSize. Updated logs and error handling and removed the previous full-universe batching loop. Updated GitHub Actions (crons.yml) to trigger the hourly candle sync and adjusted related comments. Corresponding unit tests were updated to mock the new picker behavior and assert batch-specific outcomes.