### PR TITLE
Prevent duplicate scans by gating on last research

### DIFF
--- a/src/modules/jobs/jobs.service.spec.ts
+++ b/src/modules/jobs/jobs.service.spec.ts
@@ -18,7 +18,7 @@ describe('JobsService', () => {
   const mockRiskRewardService = {
     evaluateSymbol: jest.fn(),
     getLatestScore: jest.fn(),
-    pickStaleAnalysisTickers: jest.fn(),
+    getLastAnalysisAtByTickerId: jest.fn().mockResolvedValue(new Map()),
     deleteOrphanedAnalyses: jest.fn(),
   };
 
@@ -48,6 +48,7 @@ describe('JobsService', () => {
     processTicket: jest.fn(),
     getOrGenerateDailyDigest: jest.fn(),
     reprocessFinancials: jest.fn(),
+    getLastResearchedAtBySymbol: jest.fn().mockResolvedValue(new Map()),
   };
 
   const mockRequestQueueRepo = {
@@ -294,7 +295,7 @@ describe('JobsService', () => {
   });
 
   describe('runRiskRewardScanner', () => {
-    it('queues a cron-tier ticket for each due (stale-first) ticker within budget', async () => {
+    it('queues a cron-tier ticket only for tickers that are due (stale-first)', async () => {
       const sleepSpy = jest
         .spyOn(global, 'setTimeout')
         // Resolve immediately to keep the test fast
@@ -306,11 +307,17 @@ describe('JobsService', () => {
       mockLlmBudgetService.getRemaining.mockResolvedValue(450);
       mockLlmBudgetService.hasBudget.mockResolvedValue(true);
       mockTickersService.getAllTickers.mockResolvedValue([
-        { symbol: 'AAPL' },
-        { symbol: 'TSLA' },
+        { id: '1', symbol: 'AAPL' },
+        { id: '2', symbol: 'TSLA' },
       ]);
-      // Picker decides who is due (oldest/never-analysed first).
-      mockRiskRewardService.pickStaleAnalysisTickers.mockResolvedValue(['AAPL']);
+      // AAPL has never been researched; TSLA was researched moments ago, so only
+      // AAPL is due this run.
+      mockRiskRewardService.getLastAnalysisAtByTickerId.mockResolvedValue(
+        new Map(),
+      );
+      mockResearchService.getLastResearchedAtBySymbol.mockResolvedValue(
+        new Map([['TSLA', Date.now()]]),
+      );
       mockResearchService.createResearchTicket.mockResolvedValue({
         id: 'note-1',
       });
@@ -319,9 +326,14 @@ describe('JobsService', () => {
       const result = await service.runRiskRewardScanner();
 
       expect(mockTickersService.getAllTickers).toHaveBeenCalled();
+      // Recency is looked up by internal id (analyses) and symbol (notes).
       expect(
-        mockRiskRewardService.pickStaleAnalysisTickers,
-      ).toHaveBeenCalledWith(['AAPL', 'TSLA'], expect.any(Number), expect.any(Number));
+        mockRiskRewardService.getLastAnalysisAtByTickerId,
+      ).toHaveBeenCalledWith(['1', '2']);
+      expect(
+        mockResearchService.getLastResearchedAtBySymbol,
+      ).toHaveBeenCalledWith(['AAPL', 'TSLA']);
+      expect(mockResearchService.createResearchTicket).toHaveBeenCalledTimes(1);
       expect(mockResearchService.createResearchTicket).toHaveBeenCalledWith(
         null,
         ['AAPL'],
@@ -335,15 +347,111 @@ describe('JobsService', () => {
       sleepSpy.mockRestore();
     });
 
+    // Regression: the reported bug. Forvia (FRVIA.PA) was researched ~12x/day
+    // because the gate only read risk_analyses, and that ticker's analysis row
+    // was never written (the enrichment that writes it is best-effort and
+    // swallows errors). The research_notes record IS written every run, so a
+    // ticker researched within the window must never be re-queued — even with
+    // zero risk_analyses rows.
+    it('does NOT re-queue a ticker researched within the window when it has no risk_analysis row', async () => {
+      mockLlmBudgetService.getRemaining.mockResolvedValue(450);
+      mockLlmBudgetService.hasBudget.mockResolvedValue(true);
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { id: '10', symbol: 'FRVIA.PA' },
+      ]);
+      // No analysis row exists for this ticker (the silent-write-failure case)...
+      mockRiskRewardService.getLastAnalysisAtByTickerId.mockResolvedValue(
+        new Map(),
+      );
+      // ...but it was researched moments ago, so the note recency must gate it.
+      mockResearchService.getLastResearchedAtBySymbol.mockResolvedValue(
+        new Map([['FRVIA.PA', Date.now()]]),
+      );
+
+      const result = await service.runRiskRewardScanner();
+
+      expect(mockResearchService.createResearchTicket).not.toHaveBeenCalled();
+      expect(mockResearchService.processTicket).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ processed: 0, due: 0 });
+    });
+
+    it('re-queues a ticker once its last research is older than the window', async () => {
+      const sleepSpy = jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation((callback: any) => {
+          callback();
+          return {} as NodeJS.Timeout;
+        });
+
+      mockLlmBudgetService.getRemaining.mockResolvedValue(450);
+      mockLlmBudgetService.hasBudget.mockResolvedValue(true);
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { id: '10', symbol: 'FRVIA.PA' },
+      ]);
+      mockRiskRewardService.getLastAnalysisAtByTickerId.mockResolvedValue(
+        new Map(),
+      );
+      // Researched 30 days ago — comfortably past any staleness window.
+      const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+      mockResearchService.getLastResearchedAtBySymbol.mockResolvedValue(
+        new Map([['FRVIA.PA', thirtyDaysAgo]]),
+      );
+      mockResearchService.createResearchTicket.mockResolvedValue({
+        id: 'note-9',
+      });
+      mockResearchService.processTicket.mockResolvedValue(undefined);
+
+      const result = await service.runRiskRewardScanner();
+
+      expect(mockResearchService.createResearchTicket).toHaveBeenCalledWith(
+        null,
+        ['FRVIA.PA'],
+        expect.any(String),
+        'gemini',
+        'cron',
+      );
+      expect(result).toMatchObject({ processed: 1, due: 1 });
+
+      sleepSpy.mockRestore();
+    });
+
+    it('drops tickers without an id or symbol before selecting the batch', async () => {
+      mockLlmBudgetService.getRemaining.mockResolvedValue(450);
+      mockLlmBudgetService.hasBudget.mockResolvedValue(true);
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { id: '1', symbol: 'AAPL' },
+        { symbol: 'NOID' }, // missing id
+        { id: '2' }, // missing symbol
+      ]);
+      mockRiskRewardService.getLastAnalysisAtByTickerId.mockResolvedValue(
+        new Map(),
+      );
+      mockResearchService.getLastResearchedAtBySymbol.mockResolvedValue(
+        new Map(),
+      );
+
+      await service.runRiskRewardScanner();
+
+      // Only the fully-formed candidate's id/symbol reach the recency lookups.
+      expect(
+        mockRiskRewardService.getLastAnalysisAtByTickerId,
+      ).toHaveBeenCalledWith(['1']);
+      expect(
+        mockResearchService.getLastResearchedAtBySymbol,
+      ).toHaveBeenCalledWith(['AAPL']);
+    });
+
     it('skips the whole scan when the daily LLM budget is exhausted', async () => {
       mockLlmBudgetService.getRemaining.mockResolvedValue(0);
-      mockTickersService.getAllTickers.mockResolvedValue([{ symbol: 'AAPL' }]);
+      mockTickersService.getAllTickers.mockResolvedValue([
+        { id: '1', symbol: 'AAPL' },
+      ]);
 
       const result = await service.runRiskRewardScanner();
 
       expect(result).toMatchObject({ budgetExhausted: true, processed: 0 });
       expect(
-        mockRiskRewardService.pickStaleAnalysisTickers,
+        mockRiskRewardService.getLastAnalysisAtByTickerId,
       ).not.toHaveBeenCalled();
       expect(mockResearchService.createResearchTicket).not.toHaveBeenCalled();
     });
@@ -362,13 +470,16 @@ describe('JobsService', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false);
       mockTickersService.getAllTickers.mockResolvedValue([
-        { symbol: 'AAPL' },
-        { symbol: 'MSFT' },
+        { id: '1', symbol: 'AAPL' },
+        { id: '2', symbol: 'MSFT' },
       ]);
-      mockRiskRewardService.pickStaleAnalysisTickers.mockResolvedValue([
-        'AAPL',
-        'MSFT',
-      ]);
+      // Both never researched → both due (alphabetical: AAPL, MSFT).
+      mockRiskRewardService.getLastAnalysisAtByTickerId.mockResolvedValue(
+        new Map(),
+      );
+      mockResearchService.getLastResearchedAtBySymbol.mockResolvedValue(
+        new Map(),
+      );
       mockResearchService.createResearchTicket.mockResolvedValue({
         id: 'note-1',
       });
@@ -377,9 +488,94 @@ describe('JobsService', () => {
       const result = await service.runRiskRewardScanner();
 
       expect(mockResearchService.createResearchTicket).toHaveBeenCalledTimes(1);
+      expect(mockResearchService.createResearchTicket).toHaveBeenCalledWith(
+        null,
+        ['AAPL'],
+        expect.any(String),
+        'gemini',
+        'cron',
+      );
       expect(result).toMatchObject({ processed: 1, due: 2 });
 
       sleepSpy.mockRestore();
+    });
+  });
+
+  describe('selectDueTickers (pure staleness gate)', () => {
+    const HOUR = 60 * 60 * 1000;
+    const WINDOW = 168 * HOUR; // 7 days
+    const NOW = 1_700_000_000_000;
+
+    it('treats a never-researched ticker as due', () => {
+      const due = JobsService.selectDueTickers(
+        [{ id: '1', symbol: 'AAPL' }],
+        new Map(),
+        NOW,
+        WINDOW,
+        5,
+      );
+      expect(due.map((c) => c.symbol)).toEqual(['AAPL']);
+    });
+
+    it('excludes a ticker researched within the window (the core fix)', () => {
+      const due = JobsService.selectDueTickers(
+        [{ id: '1', symbol: 'FRVIA.PA' }],
+        new Map([['1', NOW - 1 * HOUR]]), // researched 1h ago
+        NOW,
+        WINDOW,
+        5,
+      );
+      expect(due).toEqual([]);
+    });
+
+    it('includes a ticker whose last research is older than the window', () => {
+      const due = JobsService.selectDueTickers(
+        [{ id: '1', symbol: 'FRVIA.PA' }],
+        new Map([['1', NOW - 200 * HOUR]]), // researched ~8.3 days ago
+        NOW,
+        WINDOW,
+        5,
+      );
+      expect(due.map((c) => c.symbol)).toEqual(['FRVIA.PA']);
+    });
+
+    it('orders never-researched first (alphabetical), then oldest first', () => {
+      const candidates = [
+        { id: '1', symbol: 'AAPL' }, // researched 10h ago
+        { id: '2', symbol: 'ZZZ' }, // never researched
+        { id: '3', symbol: 'MSFT' }, // researched 300h ago (most stale)
+        { id: '4', symbol: 'BBB' }, // never researched
+      ];
+      const map = new Map([
+        ['1', NOW - 10 * HOUR],
+        ['3', NOW - 300 * HOUR],
+      ]);
+      const due = JobsService.selectDueTickers(
+        candidates,
+        map,
+        NOW,
+        WINDOW,
+        10,
+      );
+      // never-researched (BBB, ZZZ alphabetical) then oldest-first (MSFT before
+      // AAPL — but AAPL is within the 7d window so it isn't due at all).
+      expect(due.map((c) => c.symbol)).toEqual(['BBB', 'ZZZ', 'MSFT']);
+    });
+
+    it('respects the limit', () => {
+      const candidates = [
+        { id: '1', symbol: 'AAA' },
+        { id: '2', symbol: 'BBB' },
+        { id: '3', symbol: 'CCC' },
+      ];
+      const due = JobsService.selectDueTickers(
+        candidates,
+        new Map(),
+        NOW,
+        WINDOW,
+        2,
+      );
+      expect(due.map((c) => c.symbol)).toEqual(['AAA', 'BBB']);
     });
   });
 });

--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -293,6 +293,44 @@ export class JobsService {
    */
   static readonly RISK_SCANNER_CALLS_PER_TICKET = 2;
 
+  /**
+   * Pure selection for the universe scanner: from `candidates`, return up to
+   * `limit` tickers that are "due" for (re)research — never-researched first,
+   * then oldest first. A ticker is due when it has no recorded research/analysis
+   * at all, or its most recent one is older than `maxAgeMs`.
+   *
+   * Keyed entirely on the internal ticker `id`, so a ticker that was researched
+   * within the window is never re-queued, regardless of how its symbol is
+   * spelled. This is the gate that stops the same company being researched
+   * ~10x/day instead of once per staleness window.
+   */
+  static selectDueTickers(
+    candidates: { id: string; symbol: string }[],
+    lastResearchedAtById: Map<string, number>,
+    now: number,
+    maxAgeMs: number,
+    limit: number,
+  ): { id: string; symbol: string }[] {
+    if (candidates.length === 0 || limit <= 0) return [];
+
+    const due = candidates.filter((c) => {
+      const ts = lastResearchedAtById.get(c.id);
+      return ts === undefined || now - ts > maxAgeMs; // never researched or stale
+    });
+
+    return due
+      .sort((a, b) => {
+        const aTs = lastResearchedAtById.get(a.id);
+        const bTs = lastResearchedAtById.get(b.id);
+        if (aTs === undefined && bTs === undefined)
+          return a.symbol.localeCompare(b.symbol);
+        if (aTs === undefined) return -1; // never researched → highest priority
+        if (bTs === undefined) return 1;
+        return aTs - bTs; // oldest first
+      })
+      .slice(0, limit);
+  }
+
   async runRiskRewardScanner() {
     const maxAgeHours =
       this.configService.get<number>('riskReward.maxAgeHours') || 168;
@@ -314,27 +352,59 @@ export class JobsService {
       }
 
       const allTickers = await this.tickersService.getAllTickers();
-      const symbols = allTickers
-        .map((t) => t.symbol)
-        .filter((s): s is string => !!s);
+      // Carry the internal ticker id alongside the symbol: the staleness gate
+      // matches on id, never on the symbol string (symbols drift for
+      // suffixed/foreign tickers like FRVIA.PA and silently broke the old gate).
+      const candidates = allTickers
+        .filter((t) => !!t.symbol && t.id != null)
+        .map((t) => ({ id: String(t.id), symbol: t.symbol as string }));
 
       // Size this run to the smaller of the fixed batch and what the remaining
       // budget can afford.
       const budgetCap = Math.floor(remaining / perTicket);
       const limit = Math.min(JobsService.RISK_SCANNER_BATCH_SIZE, budgetCap);
 
-      // Stale-first rotation (never-analysed first, then oldest). Replaces the
-      // old slice(0, 5) window that only ever touched the first few tickers
-      // alphabetically and never rotated, so unwatched tickers never got
-      // scanned. Now coverage advances every run.
-      const dueSymbols = await this.riskRewardService.pickStaleAnalysisTickers(
-        symbols,
-        limit,
+      // Build one id-keyed "last researched" signal from two sources, taking the
+      // most recent of each:
+      //   - research_notes: the authoritative throttle. A note row exists for
+      //     every scan from the moment it starts, so it reliably reflects "we
+      //     researched this ticker" even when the downstream risk-analysis write
+      //     (a best-effort, error-swallowing enrichment) never lands.
+      //   - risk_analyses: keeps a ticker that already has a fresh score from
+      //     being re-scanned.
+      // Gating on risk_analyses alone is what let the same ticker be queued on
+      // every run (its analysis row was never written) and researched ~10x/day
+      // instead of once per staleness window.
+      const tickerIds = candidates.map((c) => c.id);
+      const symbols = candidates.map((c) => c.symbol);
+      const [lastAnalysisById, lastResearchBySymbol] = await Promise.all([
+        this.riskRewardService.getLastAnalysisAtByTickerId(tickerIds),
+        this.researchService.getLastResearchedAtBySymbol(symbols),
+      ]);
+
+      const lastResearchedAtById = new Map<string, number>();
+      for (const c of candidates) {
+        const latest = Math.max(
+          lastAnalysisById.get(c.id) ?? 0,
+          lastResearchBySymbol.get(c.symbol) ?? 0,
+        );
+        if (latest > 0) lastResearchedAtById.set(c.id, latest);
+      }
+
+      // Stale-first rotation (never-researched first, then oldest). Coverage
+      // advances every run; a freshly-researched ticker is excluded until its
+      // research is older than the staleness window.
+      const dueCandidates = JobsService.selectDueTickers(
+        candidates,
+        lastResearchedAtById,
+        Date.now(),
         stalenessMs,
+        limit,
       );
+      const dueSymbols = dueCandidates.map((c) => c.symbol);
 
       this.logger.log(
-        `Scanner batch (${dueSymbols.length} due / ${symbols.length} total, budget remaining: ${remaining}): ${dueSymbols.join(', ')}`,
+        `Scanner batch (${dueSymbols.length} due / ${candidates.length} total, budget remaining: ${remaining}): ${dueSymbols.join(', ')}`,
       );
 
       const DELAY_MS = 4500; // ~13 RPM, safely under the 15 RPM free limit

--- a/src/modules/research/research.service.spec.ts
+++ b/src/modules/research/research.service.spec.ts
@@ -30,6 +30,7 @@ describe('ResearchService', () => {
     findOne: jest.fn(),
     find: jest.fn(),
     delete: jest.fn(),
+    query: jest.fn(),
     createQueryBuilder: jest.fn(() => ({
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
@@ -397,6 +398,45 @@ describe('ResearchService', () => {
       const result = await service.getOrGenerateDailyDigest('system-trigger');
       expect(result).toBeNull();
       expect(mockPortfolioService.findAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getLastResearchedAtBySymbol', () => {
+    it('returns an empty map without querying when no symbols are given', async () => {
+      const result = await service.getLastResearchedAtBySymbol([]);
+
+      expect(result.size).toBe(0);
+      expect(mockRepo.query).not.toHaveBeenCalled();
+    });
+
+    it('maps each symbol to the most recent research_note created_at', async () => {
+      const tForvia = new Date('2026-06-13T10:00:00.000Z');
+      const tApple = new Date('2026-05-01T08:00:00.000Z');
+      mockRepo.query.mockResolvedValue([
+        { symbol: 'FRVIA.PA', last_at: tForvia.toISOString() },
+        { symbol: 'AAPL', last_at: tApple },
+      ]);
+
+      const result = await service.getLastResearchedAtBySymbol([
+        'FRVIA.PA',
+        'AAPL',
+      ]);
+
+      // The symbol list is passed positionally as $1 to the unnest query.
+      expect(mockRepo.query).toHaveBeenCalledWith(expect.any(String), [
+        ['FRVIA.PA', 'AAPL'],
+      ]);
+      expect(result.get('FRVIA.PA')).toBe(tForvia.getTime());
+      expect(result.get('AAPL')).toBe(tApple.getTime());
+    });
+
+    it('skips rows whose last_at is null', async () => {
+      mockRepo.query.mockResolvedValue([{ symbol: 'NEW.PA', last_at: null }]);
+
+      const result = await service.getLastResearchedAtBySymbol(['NEW.PA']);
+
+      expect(result.has('NEW.PA')).toBe(false);
+      expect(result.size).toBe(0);
     });
   });
 });

--- a/src/modules/research/research.service.ts
+++ b/src/modules/research/research.service.ts
@@ -486,6 +486,45 @@ You MUST include a "Risk/Reward Profile" section at the end of your report with 
   }
 
   /**
+   * Returns the timestamp (epoch ms) of the most recent research note that
+   * covered each of the given symbols, keyed by symbol. Symbols absent from the
+   * map have never been researched.
+   *
+   * This is the authoritative throttle for the universe scanner: a research
+   * note row is written the moment a scan starts (well before the best-effort
+   * risk-analysis enrichment runs), so it reliably records "we researched this
+   * ticker" even when the downstream analysis write fails. All statuses count —
+   * a ticker we just attempted (even one that failed) must not be re-queued
+   * every few minutes; it waits out the staleness window like any other.
+   *
+   * `research_notes.tickers` is a `text[]` of symbols (no FK), so the array is
+   * unnested and the latest note per symbol is taken in a single query.
+   */
+  async getLastResearchedAtBySymbol(
+    symbols: string[],
+  ): Promise<Map<string, number>> {
+    const map = new Map<string, number>();
+    if (symbols.length === 0) return map;
+
+    const rows: { symbol: string; last_at: string | Date | null }[] =
+      await this.noteRepo.query(
+        `SELECT s AS symbol, MAX(n.created_at) AS last_at
+           FROM research_notes n
+           CROSS JOIN LATERAL unnest(n.tickers) AS s
+          WHERE s = ANY($1)
+          GROUP BY s`,
+        [symbols],
+      );
+
+    for (const r of rows) {
+      if (r.last_at) {
+        map.set(r.symbol, new Date(r.last_at).getTime());
+      }
+    }
+    return map;
+  }
+
+  /**
    * Manually trigger financial extraction from the latest research note.
    */
   async reprocessFinancials(ticker: string): Promise<void> {

--- a/src/modules/risk-reward/risk-reward.service.spec.ts
+++ b/src/modules/risk-reward/risk-reward.service.spec.ts
@@ -16,6 +16,7 @@ describe('RiskRewardService', () => {
     find: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockOldScoreRepo = {};
@@ -413,6 +414,66 @@ describe('RiskRewardService', () => {
       expect(result.risk_score.dilution_risk).toBe(5);
       expect(result.risk_score.competitive_risk).toBe(7);
       expect(result.risk_score.regulatory_risk).toBe(4);
+    });
+  });
+
+  describe('getLastAnalysisAtByTickerId', () => {
+    const buildQb = (rows: any[]) => {
+      const qb = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      };
+      return qb;
+    };
+
+    it('returns an empty map without hitting the DB when no ids are given', async () => {
+      const result = await service.getLastAnalysisAtByTickerId([]);
+
+      expect(result.size).toBe(0);
+      expect(mockAnalysisRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('keys the latest analysis time by internal ticker id', async () => {
+      const t1 = new Date('2026-06-01T00:00:00.000Z');
+      const t2 = new Date('2026-06-10T00:00:00.000Z');
+      const qb = buildQb([
+        { ticker_id: '101', last_at: t1.toISOString() },
+        { ticker_id: '202', last_at: t2.toISOString() },
+      ]);
+      mockAnalysisRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLastAnalysisAtByTickerId(['101', '202']);
+
+      expect(qb.where).toHaveBeenCalledWith('a.ticker_id IN (:...ids)', {
+        ids: ['101', '202'],
+      });
+      expect(result.get('101')).toBe(t1.getTime());
+      expect(result.get('202')).toBe(t2.getTime());
+    });
+
+    it('coerces bigint ticker ids returned as numbers to string keys', async () => {
+      const t1 = new Date('2026-06-01T00:00:00.000Z');
+      const qb = buildQb([{ ticker_id: 101, last_at: t1.toISOString() }]);
+      mockAnalysisRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLastAnalysisAtByTickerId(['101']);
+
+      // Decision layer keys on String(id); a numeric DB row must still match.
+      expect(result.get('101')).toBe(t1.getTime());
+      expect(result.has('101')).toBe(true);
+    });
+
+    it('skips rows whose last_at is null', async () => {
+      const qb = buildQb([{ ticker_id: '303', last_at: null }]);
+      mockAnalysisRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLastAnalysisAtByTickerId(['303']);
+
+      expect(result.has('303')).toBe(false);
+      expect(result.size).toBe(0);
     });
   });
 });

--- a/src/modules/risk-reward/risk-reward.service.ts
+++ b/src/modules/risk-reward/risk-reward.service.ts
@@ -305,56 +305,38 @@ export class RiskRewardService {
   }
 
   /**
-   * Picks the `limit` most-stale tickers that are "due" for (re)analysis,
-   * never-researched first, then oldest analysis first. A ticker is due when
-   * it has no analysis at all, or its latest analysis is older than `maxAgeMs`.
+   * Returns the timestamp (epoch ms) of the most recent risk analysis for each
+   * of the given internal ticker ids, keyed by `ticker_id`. Ids absent from the
+   * map have no analysis on record.
    *
-   * This drives the universe scanner's stale-first rotation: instead of always
-   * scanning the same alphabetical window, every run advances to whatever is
-   * most overdue, so every ticker (watchlisted or not) gets covered on a
-   * rolling cadence. The whole decision is a single DB query — no per-ticker
-   * snapshot fetches.
+   * Matching is done on the internal `ticker_id` primary key — never on the
+   * symbol string. The old symbol join silently failed for suffixed/foreign
+   * tickers (e.g. FRVIA.PA), so a ticker that had been analysed still looked
+   * "never analysed" and got re-scanned on every cron run. The universe
+   * scanner consumes this (merged with research-note recency) to decide which
+   * tickers are due, never-researched first then oldest first.
    */
-  async pickStaleAnalysisTickers(
-    candidateSymbols: string[],
-    limit: number,
-    maxAgeMs: number,
-  ): Promise<string[]> {
-    if (candidateSymbols.length === 0 || limit <= 0) return [];
+  async getLastAnalysisAtByTickerId(
+    tickerIds: string[],
+  ): Promise<Map<string, number>> {
+    const map = new Map<string, number>();
+    if (tickerIds.length === 0) return map;
 
-    const rows: { symbol: string; last_at: string | null }[] =
+    const rows: { ticker_id: string; last_at: string | null }[] =
       await this.analysisRepo
         .createQueryBuilder('a')
-        .innerJoin('a.ticker', 't')
-        .select('t.symbol', 'symbol')
+        .select('a.ticker_id', 'ticker_id')
         .addSelect('MAX(a.created_at)', 'last_at')
-        .where('t.symbol IN (:...symbols)', { symbols: candidateSymbols })
-        .groupBy('t.symbol')
+        .where('a.ticker_id IN (:...ids)', { ids: tickerIds })
+        .groupBy('a.ticker_id')
         .getRawMany();
 
-    const lastAtBySymbol = new Map<string, number>();
     for (const r of rows) {
       if (r.last_at) {
-        lastAtBySymbol.set(r.symbol, new Date(r.last_at).getTime());
+        map.set(String(r.ticker_id), new Date(r.last_at).getTime());
       }
     }
-
-    const now = Date.now();
-    const due = candidateSymbols.filter((s) => {
-      const ts = lastAtBySymbol.get(s);
-      return ts === undefined || now - ts > maxAgeMs; // never analysed or stale
-    });
-
-    return due
-      .sort((a, b) => {
-        const aTs = lastAtBySymbol.get(a);
-        const bTs = lastAtBySymbol.get(b);
-        if (aTs === undefined && bTs === undefined) return a.localeCompare(b);
-        if (aTs === undefined) return -1; // never researched → highest priority
-        if (bTs === undefined) return 1;
-        return aTs - bTs; // oldest analysis first
-      })
-      .slice(0, limit);
+    return map;
   }
 
   /**

--- a/src/modules/tickers/tickers.service.ts
+++ b/src/modules/tickers/tickers.service.ts
@@ -334,9 +334,12 @@ export class TickersService {
 
   async getAllTickers(): Promise<Partial<TickerEntity>[]> {
     return this.tickerRepo.find({
-      // Include `currency` so callers (cron syncs, frontend list views) can
-      // render prices in their native currency without an extra round-trip.
-      select: ['symbol', 'name', 'exchange', 'currency'],
+      // Include `id` so callers can match on the internal primary key instead of
+      // the symbol string (symbols drift for suffixed/foreign tickers and are an
+      // unreliable join key). Include `currency` so callers (cron syncs,
+      // frontend list views) can render prices in their native currency without
+      // an extra round-trip.
+      select: ['id', 'symbol', 'name', 'exchange', 'currency'],
       where: { is_hidden: false },
       order: { symbol: 'ASC' },
     });


### PR DESCRIPTION
Add id-keyed staleness gating to the risk/reward scanner to avoid re-queuing tickers that were recently researched even if their analysis row is missing. Introduce JobsService.selectDueTickers (pure selection logic), RiskRewardService.getLastAnalysisAtByTickerId, and ResearchService.getLastResearchedAtBySymbol. Update runRiskRewardScanner to combine analysis and research recency (by internal ticker id), filter/limit candidates by id/symbol, and log counts. Include id in TickersService.getAllTickers selection. Add and update unit tests covering the regression (tickers with no analysis but recent research), selection ordering, limits, and DB query behavior.