### PR TITLE
feat(portfolio+mcp): trading simulator (sell/cash/ledger) + admin logo MCP tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ FIREBASE_API_KEY='your_firebase_api_key'
 # staging/preview/prod, where it is a full auth bypass.
 ENABLE_DEV_LOGIN='true'
 
+# --- Feature flags ---
+# Experimental pixel-terminal frontend (frontend-v2) served under /v2/.
+# OFF by default — the static route is not registered unless this is exactly
+# 'true', so /v2/* is completely unreachable. Set to 'true' to opt in.
+# FRONTEND_V2_ENABLED='true'
+
 # --- Gemini / LLM ---
 # Primary (free-tier) key. Serves the base + flash research tiers
 # (gemini-3.1-flash-lite, gemini-3.5-flash) which run on the free key.

--- a/frontend/src/components/portfolio/CashDialog.tsx
+++ b/frontend/src/components/portfolio/CashDialog.tsx
@@ -1,0 +1,250 @@
+import { useState, useEffect } from 'react';
+import {
+  Wallet,
+  Loader2,
+  AlertCircle,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+} from 'lucide-react';
+import { api } from '../../lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Tabs, TabsList, TabsTrigger } from '../ui/tabs';
+import { NativeSelect } from '../ui/select-native';
+import { toast } from 'sonner';
+
+// Mirrors the backend SUPPORTED_CURRENCIES allow-list (cash-operation.dto.ts).
+const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'CHF', 'JPY', 'CAD', 'AUD'] as const;
+
+export interface CashBalance {
+  currency: string;
+  amount: number;
+}
+
+interface CashDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  balances: CashBalance[];
+  /** Pre-select this currency (e.g. the position the user just tried to buy). */
+  defaultCurrency?: string;
+  onSuccess: () => void;
+}
+
+const formatCurrency = (val: number, currency = 'USD') =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(val);
+
+export function CashDialog({
+  open,
+  onOpenChange,
+  balances,
+  defaultCurrency = 'USD',
+  onSuccess,
+}: CashDialogProps) {
+  const [mode, setMode] = useState<'deposit' | 'withdraw'>('deposit');
+  const [amount, setAmount] = useState('');
+  const [currency, setCurrency] = useState(defaultCurrency);
+  const [note, setNote] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setMode('deposit');
+      setAmount('');
+      setNote('');
+      setError(null);
+      // Only adopt the default if it's an allowed cash currency.
+      setCurrency(
+        (SUPPORTED_CURRENCIES as readonly string[]).includes(defaultCurrency)
+          ? defaultCurrency
+          : 'USD',
+      );
+    }
+  }, [open, defaultCurrency]);
+
+  const currentBalance =
+    balances.find((b) => b.currency === currency)?.amount ?? 0;
+  const amountNum = parseFloat(amount) || 0;
+  const insufficient =
+    mode === 'withdraw' && amountNum > currentBalance + 1e-9;
+  const canSubmit = !loading && amountNum > 0 && !insufficient;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const payload: Record<string, unknown> = { amount: amountNum, currency };
+      if (note.trim()) payload.note = note.trim();
+
+      const { data } = await api.post(`/portfolio/cash/${mode}`, payload);
+      const verb = mode === 'deposit' ? 'Deposited' : 'Withdrew';
+      toast.success(`${verb} ${formatCurrency(amountNum, currency)}`, {
+        description: `${currency} balance: ${formatCurrency(Number(data?.amount ?? 0), currency)}`,
+      });
+      onSuccess();
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const e2 = err as {
+        response?: { data?: { message?: string } };
+        message?: string;
+      };
+      const msg = e2.response?.data?.message || e2.message || 'Cash operation failed';
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader className="pb-2">
+          <div className="flex items-center gap-3 mb-1">
+            <div className="p-2.5 rounded-xl bg-primary/10 text-primary shadow-sm border border-primary/20">
+              <Wallet className="w-5 h-5" />
+            </div>
+            <div>
+              <DialogTitle className="text-xl font-bold tracking-tight">
+                Manage Cash
+              </DialogTitle>
+              <DialogDescription className="text-xs">
+                Simulator cash funds your buys and holds your sale proceeds.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {/* Current balances */}
+        {balances.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {balances.map((b) => (
+              <button
+                type="button"
+                key={b.currency}
+                onClick={() => setCurrency(b.currency)}
+                className={
+                  'px-2.5 py-1 rounded-md text-xs font-mono border transition-colors ' +
+                  (b.currency === currency
+                    ? 'bg-primary/10 border-primary/40 text-foreground'
+                    : 'bg-muted/30 border-border/40 text-muted-foreground hover:text-foreground')
+                }
+              >
+                {formatCurrency(b.amount, b.currency)}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5 py-2">
+          <Tabs value={mode} onValueChange={(v) => setMode(v as 'deposit' | 'withdraw')}>
+            <TabsList className="grid w-full grid-cols-2 bg-muted/30">
+              <TabsTrigger value="deposit" className="flex items-center gap-2">
+                <ArrowDownToLine size={14} /> Deposit
+              </TabsTrigger>
+              <TabsTrigger value="withdraw" className="flex items-center gap-2">
+                <ArrowUpFromLine size={14} /> Withdraw
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          {error && (
+            <div className="p-3 bg-red-500/10 text-red-500 rounded-md text-sm flex items-center gap-2">
+              <AlertCircle size={16} />
+              {error}
+            </div>
+          )}
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-1.5 col-span-2">
+              <Label htmlFor="cash-amount" className="text-xs font-bold text-muted-foreground">
+                Amount
+              </Label>
+              <Input
+                id="cash-amount"
+                type="number"
+                step="any"
+                min="0"
+                required
+                placeholder="0.00"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                className="font-mono bg-muted/20"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs font-bold text-muted-foreground">Currency</Label>
+              <NativeSelect
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+                className="h-9"
+              >
+                {SUPPORTED_CURRENCIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </NativeSelect>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between text-xs px-1">
+            <span className="text-muted-foreground">{currency} balance</span>
+            <span className="font-mono font-semibold text-foreground">
+              {formatCurrency(currentBalance, currency)}
+            </span>
+          </div>
+          {insufficient && (
+            <p className="text-[11px] text-red-500 font-medium flex items-center gap-1 -mt-3 px-1">
+              <AlertCircle size={11} /> Amount exceeds your {currency} balance
+            </p>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cash-note" className="text-xs font-bold text-muted-foreground">
+              Note <span className="font-normal text-muted-foreground/60">(optional)</span>
+            </Label>
+            <Input
+              id="cash-note"
+              type="text"
+              placeholder="e.g. Initial funding"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="bg-muted/20"
+            />
+          </div>
+
+          <DialogFooter className="pt-2 border-t border-border/50 flex-col sm:flex-row gap-2">
+            <Button variant="ghost" type="button" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!canSubmit}
+              className="min-w-[140px] bg-primary hover:bg-primary/90 text-primary-foreground"
+            >
+              {loading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : mode === 'deposit' ? (
+                <ArrowDownToLine className="mr-2 h-4 w-4" />
+              ) : (
+                <ArrowUpFromLine className="mr-2 h-4 w-4" />
+              )}
+              {mode === 'deposit' ? 'Deposit' : 'Withdraw'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/portfolio/PortfolioGridView.tsx
+++ b/frontend/src/components/portfolio/PortfolioGridView.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { TrendingUp, TrendingDown, ArrowUp, Bot, Edit2 } from 'lucide-react';
+import { TrendingUp, TrendingDown, ArrowUp, Bot, Edit2, Banknote } from 'lucide-react';
 import { Button } from '../ui/button';
 import { TickerLogo } from '../dashboard/TickerLogo';
 import { Badge } from '../ui/badge';
@@ -32,9 +32,10 @@ interface PortfolioGridViewProps {
   data: PortfolioItem[];
   isLoading: boolean;
   onEdit: (position: PortfolioItem) => void;
+  onSell?: (position: PortfolioItem) => void;
 }
 
-export function PortfolioGridView({ data, isLoading, onEdit }: PortfolioGridViewProps) {
+export function PortfolioGridView({ data, isLoading, onEdit, onSell }: PortfolioGridViewProps) {
   const navigate = useNavigate();
 
   if (isLoading) {
@@ -111,6 +112,20 @@ export function PortfolioGridView({ data, isLoading, onEdit }: PortfolioGridView
                       <Bot size={10} />
                       {rating}
                     </Badge>
+                    {onSell && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-muted-foreground hover:text-rose-400 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSell(item);
+                        }}
+                        title="Sell Position"
+                      >
+                        <Banknote size={12} />
+                      </Button>
+                    )}
                     <Button
                       variant="ghost"
                       size="icon"
@@ -119,6 +134,7 @@ export function PortfolioGridView({ data, isLoading, onEdit }: PortfolioGridView
                         e.stopPropagation();
                         onEdit(item);
                       }}
+                      title="Edit Position"
                     >
                       <Edit2 size={12} />
                     </Button>

--- a/frontend/src/components/portfolio/PortfolioStats.tsx
+++ b/frontend/src/components/portfolio/PortfolioStats.tsx
@@ -4,7 +4,7 @@ import {
   XAxis, YAxis, Tooltip,
   ComposedChart, Area, CartesianGrid
 } from 'recharts';
-import { TrendingUp, TrendingDown, Bot, AlertTriangle } from 'lucide-react';
+import { TrendingUp, TrendingDown, Bot, AlertTriangle, Wallet, History } from 'lucide-react';
 import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
 import { format, subDays, differenceInDays, addDays, isBefore, startOfDay, parseISO, isValid } from 'date-fns';
@@ -38,6 +38,14 @@ interface PortfolioStatsProps {
   isNativeMode?: boolean;
   /** Count of rows the backend could not convert (FX rate missing). */
   conversionUnavailable?: number;
+  /** Total simulator cash, converted to displayCurrency (from /portfolio/summary). */
+  cashValue?: number;
+  /** Net worth = holdings + cash, in displayCurrency. Falls back to holdings. */
+  netWorth?: number;
+  /** Opens the deposit/withdraw cash dialog. */
+  onManageCash?: () => void;
+  /** Opens the trade-history dialog. */
+  onViewHistory?: () => void;
 }
 
 // Professional Palette - Carbon/Minimalist
@@ -113,6 +121,10 @@ export function PortfolioStats({
   displayCurrency: portfolioCurrency,
   isNativeMode = false,
   conversionUnavailable = 0,
+  cashValue,
+  netWorth,
+  onManageCash,
+  onViewHistory,
 }: PortfolioStatsProps) {
 
   const [range, setRange] = useState<Range>('1M');
@@ -311,7 +323,31 @@ export function PortfolioStats({
           <h1 className="text-3xl font-bold tracking-tight text-foreground truncate">My Portfolio</h1>
           <p className="text-sm text-muted-foreground truncate hidden sm:block">Real-time cross-asset performance analytics</p>
         </div>
-        <div className="flex-shrink-0">
+        <div className="flex-shrink-0 flex items-center gap-2">
+          {onViewHistory && (
+            <Button
+              onClick={onViewHistory}
+              variant="outline"
+              size="sm"
+              className="gap-2 h-9 text-xs"
+              title="View trade history"
+            >
+              <History size={14} />
+              <span className="hidden sm:inline">History</span>
+            </Button>
+          )}
+          {onManageCash && (
+            <Button
+              onClick={onManageCash}
+              variant="outline"
+              size="sm"
+              className="gap-2 h-9 text-xs"
+              title="Deposit or withdraw simulator cash"
+            >
+              <Wallet size={14} />
+              <span className="hidden sm:inline">Cash</span>
+            </Button>
+          )}
           <Button
             onClick={onAnalyze}
             disabled={credits <= 0}
@@ -325,7 +361,7 @@ export function PortfolioStats({
             title={credits <= 0 ? "Insufficient credits to analyze" : "Click to analyze portfolio with AI"}
           >
             <Bot size={14} className={cn(credits > 0 ? "text-white" : "text-muted-foreground")} />
-            AI Analyze
+            <span className="hidden sm:inline">AI Analyze</span>
           </Button>
         </div>
       </div>
@@ -345,11 +381,18 @@ export function PortfolioStats({
                     : undefined
                 }
               >
-                Total Net Worth
+                Net Worth
               </p>
               <h2 className="text-2xl font-bold tracking-tight text-foreground">
-                {formatTotal(totalValue)}
+                {formatTotal(netWorth ?? totalValue)}
               </h2>
+              {!isNativeMode && cashValue !== undefined && (
+                <p className="text-[11px] text-muted-foreground mt-1 font-medium">
+                  Holdings <span className="text-foreground/80 font-semibold">{formatCurrency(totalValue)}</span>
+                  <span className="mx-1.5 opacity-40">·</span>
+                  Cash <span className="text-foreground/80 font-semibold">{formatCurrency(cashValue)}</span>
+                </p>
+              )}
               {isNativeMode ? (
                 <div className="inline-flex items-center gap-1.5 mt-2 px-2.5 py-1 rounded-md text-xs font-semibold bg-muted/60 text-muted-foreground">
                   Switch from NATIVE to a single currency for totals

--- a/frontend/src/components/portfolio/PortfolioTable.tsx
+++ b/frontend/src/components/portfolio/PortfolioTable.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Edit2, ArrowUp, ArrowDown, Brain, Newspaper, MessageCircle, AlertTriangle } from 'lucide-react';
+import { Trash2, Edit2, ArrowUp, ArrowDown, Brain, Newspaper, MessageCircle, AlertTriangle, Banknote } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
 import { DataTable } from '../ui/data-table';
@@ -82,6 +82,7 @@ interface PortfolioTableProps {
     positions: Position[];
     onDelete: (id: string) => void;
     onEdit?: (position: Position) => void;
+    onSell?: (position: Position) => void;
     loading: boolean;
 }
 
@@ -93,7 +94,7 @@ const formatPct = (val: number) =>
     `${val > 0 ? '+' : ''}${val.toFixed(2)}%`;
 
 
-export function PortfolioTable({ positions, onDelete, onEdit, loading }: PortfolioTableProps) {
+export function PortfolioTable({ positions, onDelete, onEdit, onSell, loading }: PortfolioTableProps) {
     const navigate = useNavigate();
     const { displayCurrency, formatNative } = useCurrency();
     const columnHelper = createColumnHelper<Position>();
@@ -371,6 +372,18 @@ export function PortfolioTable({ positions, onDelete, onEdit, loading }: Portfol
             header: 'Actions',
             cell: (info) => (
                 <div className="flex items-center gap-1 opacity-20 group-hover:opacity-100 transition-opacity">
+                    {onSell && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onSell(info.row.original);
+                            }}
+                            className="p-1.5 rounded-md text-muted-foreground hover:text-rose-400 hover:bg-rose-500/10 transition-colors"
+                            title="Sell Position"
+                        >
+                            <Banknote size={14} />
+                        </button>
+                    )}
                     {onEdit && (
                         <button
                             onClick={(e) => {

--- a/frontend/src/components/portfolio/SellPositionDialog.tsx
+++ b/frontend/src/components/portfolio/SellPositionDialog.tsx
@@ -1,0 +1,527 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  TrendingDown,
+  Calendar as CalendarIcon,
+  Loader2,
+  AlertCircle,
+  AlertTriangle,
+  Hash,
+  Coins,
+} from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import { api, cn } from '../../lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
+import { SimpleCalendar } from '../ui/simple-calendar';
+import { TickerLogo } from '../dashboard/TickerLogo';
+import { PriceRangeSlider } from './PriceRangeSlider';
+import { Sparkline } from '../ui/Sparkline';
+import { toast } from 'sonner';
+
+// The position passed in comes straight from the (possibly currency-converted)
+// Portfolio response. Selling always operates in the position's NATIVE currency
+// — that's what the backend stores and what the SELL endpoint expects — so we
+// deliberately prefer the `original_*` fields (present only when the row was
+// converted to a display currency) over the converted ones.
+interface SellablePosition {
+  id: string;
+  symbol: string;
+  shares: number | string;
+  buy_price: number | string;
+  currency?: string;
+  original_currency?: string;
+  original_buy_price?: number;
+  original_current_price?: number;
+  current_price?: number;
+}
+
+interface OhlcDataPoint {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  median: number;
+}
+
+interface HistoryItem {
+  ts?: number;
+  date?: string;
+  time?: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+interface SnapshotData {
+  ticker?: { logo_url?: string; name?: string; industry?: string };
+  sparkline?: number[];
+  price?: number;
+  latestPrice?: { close?: number; change_percent?: number };
+  change_percent?: number;
+}
+
+interface SellPositionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  position: SellablePosition;
+  onSuccess: () => void;
+}
+
+export function SellPositionDialog({
+  open,
+  onOpenChange,
+  position,
+  onSuccess,
+}: SellPositionDialogProps) {
+  const [shares, setShares] = useState('');
+  const [price, setPrice] = useState('');
+  const [fees, setFees] = useState('');
+  const [date, setDate] = useState('');
+  const [note, setNote] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [ohlcData, setOhlcData] = useState<OhlcDataPoint[]>([]);
+  const [snapshot, setSnapshot] = useState<SnapshotData | null>(null);
+
+  // Everything in this dialog is native-currency. `original_*` exist only when
+  // the row was converted; fall back to the (then-native) plain fields.
+  const nativeCurrency =
+    position?.original_currency || position?.currency || 'USD';
+  const held = Number(position?.shares) || 0;
+  const nativeBuyPrice = Number(position?.original_buy_price ?? position?.buy_price) || 0;
+  const nativeCurrentPrice = Number(
+    position?.original_current_price ?? position?.current_price ?? 0,
+  );
+
+  const formatNative = (val: number) =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: nativeCurrency,
+    }).format(val);
+  const currencySymbol = (0)
+    .toLocaleString('en-US', {
+      style: 'currency',
+      currency: nativeCurrency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })
+    .replace(/\d/g, '')
+    .trim();
+
+  // Initialise from the position each time the dialog opens. Default to selling
+  // the entire lot (the most common action) at today's live price.
+  useEffect(() => {
+    if (position && open) {
+      setShares(String(held));
+      setFees('');
+      setNote('');
+      setDate(new Date().toISOString().split('T')[0]);
+      setPrice(nativeCurrentPrice ? nativeCurrentPrice.toFixed(2) : '');
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [position?.id, open]);
+
+  // Pull live snapshot + history so the slider has a real OHLC range and the
+  // default sale price tracks the live market price.
+  useEffect(() => {
+    if (!position?.symbol || !open) return;
+
+    const fetchHistory = async () => {
+      try {
+        const historyPromise = api.get<HistoryItem[]>(
+          `/tickers/${position.symbol}/history`,
+          { params: { days: 1825 } },
+        );
+        const snapshotPromise = api
+          .get<SnapshotData>(`/tickers/${position.symbol}/snapshot`)
+          .catch(() => ({ data: {} as SnapshotData }));
+
+        const [historyRes, snapshotRes] = await Promise.all([
+          historyPromise,
+          snapshotPromise,
+        ]);
+        setSnapshot(snapshotRes.data);
+
+        const combined = historyRes.data.map((item) => {
+          const val = item.ts || item.date || item.time;
+          let dateStr = String(val);
+          if (typeof val === 'number') {
+            dateStr = new Date(val * 1000).toISOString().split('T')[0];
+          } else if (val) {
+            try {
+              dateStr = new Date(val as string | number | Date)
+                .toISOString()
+                .split('T')[0];
+            } catch {
+              dateStr = String(val);
+            }
+          }
+          return {
+            date: dateStr,
+            open: item.open,
+            high: item.high,
+            low: item.low,
+            close: item.close,
+            median: (item.high + item.low) / 2,
+          };
+        });
+        setOhlcData(combined);
+
+        // Prefer the live snapshot close for the default sale price.
+        const live = snapshotRes.data?.price || snapshotRes.data?.latestPrice?.close;
+        if (live) {
+          setPrice((prev) => (prev ? prev : Number(live).toFixed(2)));
+        }
+      } catch {
+        // Non-fatal — the user can still type a price.
+      }
+    };
+
+    fetchHistory();
+  }, [position?.symbol, open]);
+
+  const validDates = useMemo(
+    () => new Set(ohlcData.map((d) => d.date).filter(Boolean)),
+    [ohlcData],
+  );
+
+  const selectedDateData = useMemo(
+    () => ohlcData.find((d) => d.date === date),
+    [ohlcData, date],
+  );
+
+  const effectiveDateData = useMemo(() => {
+    if (selectedDateData) return selectedDateData;
+    if (ohlcData.length === 0 || !date) return null;
+    const target = new Date(date).getTime();
+    const sorted = [...ohlcData].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    );
+    return sorted.find((d) => new Date(d.date).getTime() <= target) || sorted[0];
+  }, [ohlcData, date, selectedDateData]);
+
+  // --- Live P&L preview (all native) ---
+  const sharesNum = parseFloat(shares) || 0;
+  const priceNum = parseFloat(price) || 0;
+  const feesNum = parseFloat(fees) || 0;
+  const gross = sharesNum * priceNum;
+  const proceeds = Math.max(0, gross - feesNum);
+  const costBasis = sharesNum * nativeBuyPrice;
+  const realizedPnl = proceeds - costBasis;
+  const isProfit = realizedPnl >= 0;
+  const remainingShares = Math.max(0, held - sharesNum);
+
+  // Allow a tiny epsilon so "sell all" via the Max button isn't blocked by
+  // floating-point representation of the held amount.
+  const oversold = sharesNum > held + 1e-9;
+  const canSubmit =
+    !loading && sharesNum > 0 && priceNum > 0 && !oversold;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const payload: Record<string, unknown> = {
+        shares: sharesNum,
+        price: priceNum,
+        sell_date: date,
+      };
+      if (feesNum > 0) payload.fees = feesNum;
+      if (note.trim()) payload.note = note.trim();
+
+      const { data } = await api.post(
+        `/portfolio/positions/${position.id}/sell`,
+        payload,
+      );
+
+      const realized = Number(data?.realized_pnl ?? realizedPnl);
+      const got = Number(data?.proceeds ?? proceeds);
+      toast.success(
+        `Sold ${sharesNum} ${position.symbol} for ${formatNative(got)}`,
+        {
+          description: `Realized P&L ${realized >= 0 ? '+' : ''}${formatNative(realized)} · credited to ${nativeCurrency} cash`,
+        },
+      );
+      onSuccess();
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const e2 = err as {
+        response?: { data?: { message?: string } };
+        message?: string;
+      };
+      const msg =
+        e2.response?.data?.message || e2.message || 'Failed to sell position';
+      setError(msg);
+      toast.error('Failed to sell position');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] overflow-visible">
+        <DialogHeader className="pb-2">
+          <div className="flex items-center gap-3 mb-1">
+            <div className="p-2.5 rounded-xl bg-rose-500/10 text-rose-500 shadow-sm border border-rose-500/20">
+              <TrendingDown className="w-5 h-5" />
+            </div>
+            <div>
+              <DialogTitle className="text-xl font-bold tracking-tight">
+                Sell Position
+              </DialogTitle>
+              <DialogDescription className="text-xs">
+                Proceeds are credited to your {nativeCurrency} cash balance.
+              </DialogDescription>
+            </div>
+          </div>
+
+          {/* Position summary card */}
+          <div className="bg-muted/30 rounded-xl border border-border/40 p-4 flex items-center justify-between gap-4 mb-1">
+            <div className="flex items-center gap-4 flex-1 min-w-0">
+              <TickerLogo
+                url={snapshot?.ticker?.logo_url}
+                symbol={position.symbol}
+                className="w-12 h-12 rounded-full shadow-lg border-2 border-background flex-shrink-0"
+              />
+              <div className="min-w-0">
+                <h3 className="text-lg font-bold text-foreground leading-none">
+                  {position.symbol}
+                </h3>
+                <p className="text-sm text-muted-foreground font-medium truncate">
+                  {snapshot?.ticker?.name || position.symbol}
+                </p>
+                <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                  Holding{' '}
+                  <strong className="text-foreground/80">{held}</strong> sh · Avg{' '}
+                  {formatNative(nativeBuyPrice)}
+                </p>
+              </div>
+            </div>
+
+            {snapshot?.sparkline && snapshot.sparkline.length > 0 && (
+              <div className="hidden sm:flex flex-col items-center gap-1 flex-shrink-0">
+                <Sparkline data={snapshot.sparkline} width={90} height={30} />
+                <span className="text-[9px] text-muted-foreground/60 tracking-tighter">
+                  Last 14 days
+                </span>
+              </div>
+            )}
+
+            <div className="flex flex-col items-end flex-shrink-0">
+              <div className="text-lg font-mono font-bold tracking-tight text-foreground">
+                {formatNative(
+                  snapshot?.price || snapshot?.latestPrice?.close || nativeCurrentPrice,
+                )}
+              </div>
+              <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wider">
+                Live
+              </span>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-5 py-2">
+          {error && (
+            <div className="p-3 bg-red-500/10 text-red-500 rounded-md text-sm flex items-center gap-2">
+              <AlertCircle size={16} />
+              {error}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            {/* Shares to sell */}
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="sell-shares" className="text-xs font-bold text-muted-foreground">
+                  Shares to Sell
+                </Label>
+                <button
+                  type="button"
+                  onClick={() => setShares(String(held))}
+                  className="text-[10px] font-bold text-primary hover:underline"
+                >
+                  MAX {held}
+                </button>
+              </div>
+              <div className="relative">
+                <Hash className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="sell-shares"
+                  type="number"
+                  step="any"
+                  required
+                  placeholder="0.00"
+                  value={shares}
+                  onChange={(e) => setShares(e.target.value)}
+                  className="pl-9 font-mono bg-muted/20"
+                />
+              </div>
+              {oversold ? (
+                <p className="text-[11px] text-red-500 font-medium flex items-center gap-1">
+                  <AlertTriangle size={11} /> Only {held} held
+                </p>
+              ) : (
+                <p className="text-[11px] text-muted-foreground">
+                  Remaining: <strong>{remainingShares}</strong> sh
+                </p>
+              )}
+            </div>
+
+            {/* Sale date */}
+            <div className="space-y-1.5">
+              <Label className="text-xs font-bold text-muted-foreground">Sale Date</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    type="button"
+                    className={cn(
+                      'w-full justify-start text-left font-normal bg-muted/10 h-10',
+                      !date && 'text-muted-foreground',
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 h-4 w-4 text-muted-foreground" />
+                    {date ? format(parseISO(date), 'PP') : <span>Pick a date</span>}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0 z-[9999]" align="start">
+                  <SimpleCalendar
+                    value={date ? parseISO(date) : new Date()}
+                    onChange={(d) => setDate(format(d, 'yyyy-MM-dd'))}
+                    enabledDates={ohlcData.length > 0 ? validDates : undefined}
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          {/* Price slider */}
+          <div className="bg-muted/10 px-3 py-1 rounded-lg border border-border/50">
+            {ohlcData.length === 0 ? (
+              <div className="py-2">
+                <Label htmlFor="sell-price" className="text-xs font-bold text-muted-foreground">
+                  Sale Price
+                </Label>
+                <div className="relative mt-1.5">
+                  <span className="absolute left-3 top-2.5 text-sm text-muted-foreground font-bold font-mono w-4 text-center">
+                    {currencySymbol}
+                  </span>
+                  <Input
+                    id="sell-price"
+                    type="number"
+                    step="any"
+                    required
+                    placeholder="0.00"
+                    value={price}
+                    onChange={(e) => setPrice(e.target.value)}
+                    className="pl-9 font-mono bg-muted/20"
+                  />
+                </div>
+              </div>
+            ) : (
+              <>
+                {effectiveDateData && !selectedDateData && (
+                  <div className="text-[10px] text-orange-500 pt-2 flex items-center gap-1">
+                    <AlertCircle size={10} />
+                    <span>Using data from {effectiveDateData.date}</span>
+                  </div>
+                )}
+                <PriceRangeSlider
+                  low={effectiveDateData?.low ?? 0}
+                  high={effectiveDateData?.high ?? 100}
+                  median={effectiveDateData?.median ?? 50}
+                  value={priceNum || effectiveDateData?.close || 0}
+                  onChange={(val) => setPrice(val.toFixed(2))}
+                  className={cn('pt-0 pb-2', !effectiveDateData && 'opacity-50 grayscale')}
+                  currency={nativeCurrency}
+                />
+              </>
+            )}
+          </div>
+
+          {/* Fees (optional) */}
+          <div className="space-y-1.5">
+            <Label htmlFor="sell-fees" className="text-xs font-bold text-muted-foreground">
+              Fees <span className="font-normal text-muted-foreground/60">(optional)</span>
+            </Label>
+            <div className="relative">
+              <Coins className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="sell-fees"
+                type="number"
+                step="any"
+                min="0"
+                placeholder="0.00"
+                value={fees}
+                onChange={(e) => setFees(e.target.value)}
+                className="pl-9 font-mono bg-muted/20"
+              />
+            </div>
+          </div>
+
+          {/* P&L preview */}
+          <div className="rounded-xl border border-border/50 bg-card/60 divide-y divide-border/40">
+            <div className="flex items-center justify-between px-4 py-2.5">
+              <span className="text-xs text-muted-foreground">Gross proceeds</span>
+              <span className="text-sm font-mono font-semibold text-foreground">
+                {formatNative(proceeds)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between px-4 py-2.5">
+              <span className="text-xs text-muted-foreground">Cost basis</span>
+              <span className="text-sm font-mono text-muted-foreground">
+                {formatNative(costBasis)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between px-4 py-3 bg-muted/20 rounded-b-xl">
+              <span className="text-xs font-bold text-foreground">Realized P&amp;L</span>
+              <span
+                className={cn(
+                  'text-base font-mono font-bold',
+                  isProfit ? 'text-emerald-500' : 'text-rose-500',
+                )}
+              >
+                {isProfit ? '+' : ''}
+                {formatNative(realizedPnl)}
+              </span>
+            </div>
+          </div>
+
+          <DialogFooter className="pt-2 border-t border-border/50 flex-col sm:flex-row gap-2">
+            <Button variant="ghost" type="button" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!canSubmit}
+              className="bg-rose-600 hover:bg-rose-700 text-white min-w-[140px]"
+            >
+              {loading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <TrendingDown className="mr-2 h-4 w-4" />
+              )}
+              Sell {position.symbol}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/portfolio/TradeHistoryDialog.tsx
+++ b/frontend/src/components/portfolio/TradeHistoryDialog.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  History,
+  Loader2,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Inbox,
+} from 'lucide-react';
+import { format, parseISO, isValid } from 'date-fns';
+import { api, cn } from '../../lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../ui/dialog';
+
+// Trade rows come straight off the entity; Postgres decimal columns arrive as
+// strings, so every numeric field is coerced with Number() before display.
+interface Trade {
+  id: string;
+  symbol: string;
+  side: 'buy' | 'sell';
+  shares: string | number;
+  price: string | number;
+  total_value: string | number;
+  fees: string | number;
+  realized_pnl: string | number | null;
+  currency: string;
+  trade_date: string;
+  source: string;
+  note?: string | null;
+}
+
+interface TradeHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Restrict history to a single symbol when provided. */
+  symbol?: string;
+}
+
+const fmt = (val: number, currency = 'USD') =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(val);
+
+const fmtDate = (d: string) => {
+  try {
+    const parsed = parseISO(d);
+    return isValid(parsed) ? format(parsed, 'PP') : d;
+  } catch {
+    return d;
+  }
+};
+
+export function TradeHistoryDialog({
+  open,
+  onOpenChange,
+  symbol,
+}: TradeHistoryDialogProps) {
+  const [trades, setTrades] = useState<Trade[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get<Trade[]>('/portfolio/trades', {
+        params: { ...(symbol ? { symbol } : {}), limit: 200 },
+      });
+      setTrades(Array.isArray(data) ? data : []);
+    } catch {
+      setError('Failed to load trade history');
+    } finally {
+      setLoading(false);
+    }
+  }, [symbol]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[760px]">
+        <DialogHeader className="pb-2">
+          <div className="flex items-center gap-3">
+            <div className="p-2.5 rounded-xl bg-primary/10 text-primary shadow-sm border border-primary/20">
+              <History className="w-5 h-5" />
+            </div>
+            <div>
+              <DialogTitle className="text-xl font-bold tracking-tight">
+                Trade History{symbol ? ` — ${symbol}` : ''}
+              </DialogTitle>
+              <DialogDescription className="text-xs">
+                Every buy and sell, including trades consolidated from other apps.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="py-16 flex items-center justify-center text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading…
+          </div>
+        ) : error ? (
+          <div className="py-16 text-center text-red-500 text-sm">{error}</div>
+        ) : trades.length === 0 ? (
+          <div className="py-16 flex flex-col items-center justify-center text-center text-muted-foreground">
+            <Inbox className="h-8 w-8 mb-3 opacity-40" />
+            <p className="text-sm font-medium">No trades yet</p>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              Buy or sell a position to start your trade ledger.
+            </p>
+          </div>
+        ) : (
+          <div className="max-h-[60vh] overflow-y-auto rounded-lg border border-border/50">
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 bg-card z-10">
+                <tr className="text-[11px] uppercase tracking-wider text-muted-foreground border-b border-border/50">
+                  <th className="text-left font-semibold px-3 py-2.5">Date</th>
+                  <th className="text-left font-semibold px-3 py-2.5">Symbol</th>
+                  <th className="text-left font-semibold px-3 py-2.5">Side</th>
+                  <th className="text-right font-semibold px-3 py-2.5">Shares</th>
+                  <th className="text-right font-semibold px-3 py-2.5 hidden sm:table-cell">Price</th>
+                  <th className="text-right font-semibold px-3 py-2.5">Total</th>
+                  <th className="text-right font-semibold px-3 py-2.5">P&amp;L</th>
+                  <th className="text-right font-semibold px-3 py-2.5 hidden md:table-cell">Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {trades.map((t) => {
+                  const isBuy = t.side === 'buy';
+                  const pnl = t.realized_pnl == null ? null : Number(t.realized_pnl);
+                  return (
+                    <tr
+                      key={t.id}
+                      className="border-b border-border/30 last:border-0 hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="px-3 py-2.5 text-muted-foreground whitespace-nowrap">
+                        {fmtDate(t.trade_date)}
+                      </td>
+                      <td className="px-3 py-2.5 font-bold text-foreground">{t.symbol}</td>
+                      <td className="px-3 py-2.5">
+                        <span
+                          className={cn(
+                            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-bold',
+                            isBuy
+                              ? 'bg-emerald-500/10 text-emerald-500'
+                              : 'bg-rose-500/10 text-rose-500',
+                          )}
+                        >
+                          {isBuy ? <ArrowDownToLine size={11} /> : <ArrowUpFromLine size={11} />}
+                          {isBuy ? 'BUY' : 'SELL'}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono">
+                        {Number(t.shares)}
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono text-muted-foreground hidden sm:table-cell">
+                        {fmt(Number(t.price), t.currency)}
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono font-medium">
+                        {fmt(Number(t.total_value), t.currency)}
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono">
+                        {pnl == null ? (
+                          <span className="text-muted-foreground/50">—</span>
+                        ) : (
+                          <span className={pnl >= 0 ? 'text-emerald-500' : 'text-rose-500'}>
+                            {pnl >= 0 ? '+' : ''}
+                            {fmt(pnl, t.currency)}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2.5 text-right hidden md:table-cell">
+                        <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 bg-muted/40 px-1.5 py-0.5 rounded">
+                          {t.source}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,13 @@ import { McpToolsModule } from './modules/mcp/mcp-tools.module';
 import configuration from './config/configuration';
 // ...
 
+// Feature flag: the experimental pixel-terminal frontend (served under /v2/) is
+// OFF by default and only mounted when FRONTEND_V2_ENABLED=true. Evaluated here
+// at module-load time — not via ConfigService — because ServeStaticModule has to
+// be conditionally present in the static @Module imports array, before DI (and
+// therefore ConfigService) exists.
+const frontendV2Enabled = process.env.FRONTEND_V2_ENABLED === 'true';
+
 @Module({
   imports: [
     // ... imports
@@ -49,10 +56,17 @@ import configuration from './config/configuration';
     // Experimental pixel-terminal frontend served under /v2/ (more specific
     // prefix listed first so it claims /v2/* before the catch-all client root).
     // Built artifact lives under frontend-v2/dist after `npm run build`.
-    ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '..', 'frontend-v2', 'dist'),
-      serveRoot: '/v2',
-    }),
+    // Gated behind FRONTEND_V2_ENABLED: when disabled (the default) the static
+    // module is not registered at all, so /v2/* falls through to the catch-all
+    // client SPA below — the v2 frontend is completely unreachable.
+    ...(frontendV2Enabled
+      ? [
+          ServeStaticModule.forRoot({
+            rootPath: join(__dirname, '..', 'frontend-v2', 'dist'),
+            serveRoot: '/v2',
+          }),
+        ]
+      : []),
 
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'client'),

--- a/src/migrations/1782069397844-AddTradingSimulator.ts
+++ b/src/migrations/1782069397844-AddTradingSimulator.ts
@@ -1,0 +1,92 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Trading-simulator schema: an append-only trade ledger and a per-currency
+ * cash balance.
+ *
+ * Existing portfolios are left untouched — no cash is retroactively charged and
+ * everyone starts at a zero balance (a missing cash row IS zero). To make the
+ * history complete from day one, each existing position is backfilled as a
+ * synthetic 'backfill' BUY trade; these do NOT move cash.
+ */
+export class AddTradingSimulator1782069397844 implements MigrationInterface {
+  name = 'AddTradingSimulator1782069397844';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Per-currency cash balance (one row per user+currency).
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "portfolio_cash_balances" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "currency" varchar(3) NOT NULL,
+        "amount" numeric(20,2) NOT NULL DEFAULT 0,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_portfolio_cash_user_currency"
+      ON "portfolio_cash_balances" ("user_id", "currency")
+    `);
+
+    // Append-only trade ledger.
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "portfolio_trades" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "position_id" uuid NULL REFERENCES "portfolio_positions"("id") ON DELETE SET NULL,
+        "symbol" varchar NOT NULL,
+        "side" varchar(4) NOT NULL,
+        "shares" numeric(20,8) NOT NULL,
+        "price" numeric(20,8) NOT NULL,
+        "total_value" numeric(20,2) NOT NULL,
+        "fees" numeric(20,2) NOT NULL DEFAULT 0,
+        "realized_pnl" numeric(20,2) NULL,
+        "currency" varchar(3) NOT NULL DEFAULT 'USD',
+        "trade_date" date NOT NULL,
+        "source" varchar(32) NOT NULL DEFAULT 'app',
+        "external_id" varchar(128) NULL,
+        "note" text NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_portfolio_trades_user_symbol"
+      ON "portfolio_trades" ("user_id", "symbol")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_portfolio_trades_user_date"
+      ON "portfolio_trades" ("user_id", "trade_date")
+    `);
+    // Idempotency for MCP-consolidated imports: a given source trade is recorded
+    // at most once per user. Partial so app-originated trades (NULL) are exempt.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_portfolio_trades_user_external"
+      ON "portfolio_trades" ("user_id", "external_id")
+      WHERE "external_id" IS NOT NULL
+    `);
+
+    // Backfill: one synthetic BUY per existing position so the ledger matches
+    // current holdings on day one. Guarded so a partial re-run can't duplicate.
+    await queryRunner.query(`
+      INSERT INTO "portfolio_trades"
+        ("user_id", "position_id", "symbol", "side", "shares", "price",
+         "total_value", "fees", "currency", "trade_date", "source")
+      SELECT
+        p."user_id", p."id", p."symbol", 'buy', p."shares", p."buy_price",
+        ROUND(p."shares" * p."buy_price", 2), 0,
+        COALESCE(p."currency", 'USD'), p."buy_date", 'backfill'
+      FROM "portfolio_positions" p
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "portfolio_trades" t
+        WHERE t."position_id" = p."id" AND t."source" = 'backfill'
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "portfolio_trades"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "portfolio_cash_balances"`);
+  }
+}

--- a/src/modules/mcp/dto/serializers.ts
+++ b/src/modules/mcp/dto/serializers.ts
@@ -95,6 +95,35 @@ export function serializePortfolioPosition(p: any): Record<string, unknown> {
   };
 }
 
+/** A trade-ledger entry. Strips the `user` and `position` relations. */
+export function serializePortfolioTrade(t: any): Record<string, unknown> {
+  return {
+    id: t.id,
+    symbol: t.symbol,
+    side: t.side,
+    shares: Number(t.shares),
+    price: Number(t.price),
+    total_value: Number(t.total_value),
+    fees: Number(t.fees),
+    realized_pnl: t.realized_pnl == null ? null : Number(t.realized_pnl),
+    currency: t.currency,
+    trade_date: t.trade_date,
+    source: t.source,
+    external_id: t.external_id,
+    note: t.note,
+    position_id: t.position_id,
+    created_at: t.created_at,
+  };
+}
+
+/** A single cash balance row ({ currency, amount }). */
+export function serializeCashBalance(c: any): Record<string, unknown> {
+  return {
+    currency: c.currency,
+    amount: Number(c.amount),
+  };
+}
+
 /** Price alert. Strips the `user` and full `ticker` relations. */
 export function serializePriceAlert(a: any): Record<string, unknown> {
   return {
@@ -155,5 +184,30 @@ export function serializeWatchlist(w: any): Record<string, unknown> {
     created_at: w.created_at,
     updated_at: w.updated_at,
     items: Array.isArray(w.items) ? w.items.map(serializeWatchlistItem) : [],
+  };
+}
+
+/**
+ * Admin Logo Manager row. Whitelists the branding-relevant ticker fields and
+ * normalizes the logo state: a saved string `'null'` (seen in legacy rows) and
+ * empty strings are treated as "no logo". Accepts both a full `TickerEntity`
+ * (from `updateLogo`) and the partial select from `searchTickersAdmin`.
+ */
+export function serializeAdminTickerLogo(
+  t: any,
+): Record<string, unknown> | null {
+  if (!t) return null;
+  const logoUrl: string | null =
+    typeof t.logo_url === 'string' && t.logo_url.trim() && t.logo_url !== 'null'
+      ? t.logo_url
+      : null;
+  return {
+    id: t.id != null ? String(t.id) : undefined,
+    symbol: t.symbol,
+    name: t.name,
+    exchange: t.exchange,
+    currency: t.currency,
+    logo_url: logoUrl,
+    has_logo: logoUrl !== null,
   };
 }

--- a/src/modules/mcp/mcp-tools.module.ts
+++ b/src/modules/mcp/mcp-tools.module.ts
@@ -18,6 +18,7 @@ import { RiskTools } from './tools/risk.tools';
 import { ResearchTools } from './tools/research.tools';
 import { PortfolioTools } from './tools/portfolio.tools';
 import { TickerRequestsTools } from './tools/ticker-requests.tools';
+import { LogoTools } from './tools/logo.tools';
 
 /**
  * In-process Model Context Protocol (MCP) server.
@@ -70,6 +71,7 @@ import { TickerRequestsTools } from './tools/ticker-requests.tools';
     ResearchTools,
     PortfolioTools,
     TickerRequestsTools,
+    LogoTools,
   ],
 })
 export class McpToolsModule {}

--- a/src/modules/mcp/tools/logo.tools.ts
+++ b/src/modules/mcp/tools/logo.tools.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { Tool } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { TickersService } from '../../tickers/tickers.service';
+import { requireAdmin } from '../auth/mcp-user.util';
+import { serializeAdminTickerLogo, toolJson } from '../dto/serializers';
+
+const symbol = z
+  .string()
+  .trim()
+  .min(1)
+  .max(15)
+  .describe('Ticker symbol, e.g. "AAPL" or "ASSA-B.ST".')
+  .transform((s) => s.toUpperCase());
+
+// Real validation (https + no private/internal hosts) is done in the handler
+// via TickersService.isSafeRemoteImageUrl so the SSRF guard stays the single
+// source of truth; the schema only bounds the raw string.
+const logoUrl = z
+  .string()
+  .trim()
+  .min(1)
+  .max(2048)
+  .describe(
+    'Public HTTPS URL of the company logo image (PNG/SVG/JPG). Must be reachable ' +
+      'over https and must not point at a private/internal host — the image is ' +
+      'fetched and cached server-side.',
+  );
+
+/**
+ * Admin-only "Logo Manager" tools — the MCP equivalent of the web admin Logo
+ * Manager panel ("Manually assign logo URLs to tickers, e.g. for those missing
+ * from Finnhub"). Every handler enforces `requireAdmin`.
+ *
+ *  - `list_ticker_logos` mirrors the panel's search + "Show Missing Logos Only"
+ *    filter (`TickersService.searchTickersAdmin`).
+ *  - `set_ticker_logo` mirrors the per-row "New Logo URL" + Save, i.e. the
+ *    admin `PATCH /api/tickers/:symbol` route (`TickersService.updateLogo`):
+ *    it stores `logo_url` and downloads + caches the image in the background,
+ *    which is then served at `GET /api/tickers/:symbol/logo`.
+ */
+@Injectable()
+export class LogoTools {
+  constructor(private readonly tickers: TickersService) {}
+
+  @Tool({
+    name: 'list_ticker_logos',
+    description:
+      'Admin only. List tracked tickers with their current logo URL, to find ' +
+      'which ones still need a logo. Mirrors the admin "Logo Manager" panel. ' +
+      'Set missing_only=true to return only tickers with a missing/empty logo ' +
+      '(the "Show Missing Logos Only" filter). Optional search matches the ' +
+      'symbol or name by prefix. Returns at most 50 rows (symbol order); narrow ' +
+      'with search to reach more. Each row includes has_logo and the logo_url.',
+    parameters: z.object({
+      search: z
+        .string()
+        .trim()
+        .max(64)
+        .optional()
+        .describe('Optional symbol/name prefix filter, e.g. "AAL" or "Anglo".'),
+      missing_only: z
+        .boolean()
+        .optional()
+        .describe(
+          'When true, return only tickers whose logo URL is missing or empty.',
+        ),
+    }),
+  })
+  async listTickerLogos(
+    args: { search?: string; missing_only?: boolean },
+    _ctx: unknown,
+    req: any,
+  ) {
+    requireAdmin(req);
+    const rows = await this.tickers.searchTickersAdmin(
+      args.search,
+      args.missing_only ?? false,
+    );
+    return toolJson(rows.map(serializeAdminTickerLogo));
+  }
+
+  @Tool({
+    name: 'set_ticker_logo',
+    description:
+      'Admin only. Set (or replace) the logo for a tracked ticker by symbol. ' +
+      'Provide a public HTTPS image URL; the server saves it as the ticker ' +
+      'logo_url and downloads + caches the image (served at ' +
+      'GET /api/tickers/{symbol}/logo). Use this for tickers missing a logo ' +
+      'from Finnhub — find them with list_ticker_logos (missing_only=true). ' +
+      'The symbol must already be tracked (add it first with add_ticker). ' +
+      'Rejects non-HTTPS URLs and private/internal/metadata hosts (SSRF guard).',
+    parameters: z.object({ symbol, logo_url: logoUrl }),
+  })
+  async setTickerLogo(
+    args: { symbol: string; logo_url: string },
+    _ctx: unknown,
+    req: any,
+  ) {
+    requireAdmin(req);
+    // Reuse the exact SSRF guard the background downloader uses, so an unsafe
+    // URL is rejected up-front (with a clear message) instead of being silently
+    // stored as a logo_url whose image can never be fetched/cached.
+    if (!TickersService.isSafeRemoteImageUrl(args.logo_url)) {
+      throw new Error(
+        'logo_url must be a public https:// image URL. Non-https URLs and ' +
+          'localhost / private / internal / cloud-metadata hosts are rejected ' +
+          'so the logo can be safely fetched and cached.',
+      );
+    }
+    const ticker = await this.tickers.updateLogo(args.symbol, args.logo_url);
+    return toolJson(serializeAdminTickerLogo(ticker));
+  }
+}

--- a/src/modules/mcp/tools/portfolio.tools.ts
+++ b/src/modules/mcp/tools/portfolio.tools.ts
@@ -7,6 +7,8 @@ import { PriceAlertsService } from '../../price-alerts/price-alerts.service';
 import { requireUser } from '../auth/mcp-user.util';
 import {
   serializePortfolioPosition,
+  serializePortfolioTrade,
+  serializeCashBalance,
   serializePriceAlert,
   serializeWatchlist,
   toolJson,
@@ -175,6 +177,271 @@ export class PortfolioTools {
   async getPortfolioRecommendation(_args: unknown, _ctx: unknown, req: any) {
     const user = requireUser(req);
     return toolJson(await this.portfolio.getQuickRecommendation(user.id));
+  }
+
+  // ---- Trading simulator: sell, cash, trade history -----------------------
+
+  @Tool({
+    name: 'sell_portfolio_position',
+    description:
+      'Sell shares of an existing position. Reduces (or closes) the lot, ' +
+      'books realized P&L, and credits the proceeds (gross − fees) to the ' +
+      'matching-currency cash balance. Returns the updated position (null if ' +
+      'fully sold), the trade, proceeds and realized P&L.',
+    parameters: z.object({
+      id: z
+        .string()
+        .trim()
+        .min(1)
+        .describe('The portfolio position id to sell.'),
+      shares: z.number().min(0.0001).describe('Number of shares to sell.'),
+      price: z.number().min(0.0001).describe('Sale price per share.'),
+      sell_date: z
+        .string()
+        .trim()
+        .optional()
+        .describe('Sale date YYYY-MM-DD. Defaults to today.'),
+      fees: z
+        .number()
+        .min(0)
+        .optional()
+        .describe('Transaction fees deducted from proceeds.'),
+      note: z.string().trim().optional().describe('Optional free-text note.'),
+    }),
+  })
+  async sellPortfolioPosition(
+    args: {
+      id: string;
+      shares: number;
+      price: number;
+      sell_date?: string;
+      fees?: number;
+      note?: string;
+    },
+    _ctx: unknown,
+    req: any,
+  ) {
+    const user = requireUser(req);
+    const result = await this.portfolio.sell(user.id, args.id, {
+      shares: args.shares,
+      price: args.price,
+      sell_date: args.sell_date,
+      fees: args.fees,
+      note: args.note,
+    });
+    return toolJson({
+      position: result.position
+        ? serializePortfolioPosition(result.position)
+        : null,
+      trade: serializePortfolioTrade(result.trade),
+      proceeds: result.proceeds,
+      realized_pnl: result.realized_pnl,
+      cash_balance: result.cash_balance,
+    });
+  }
+
+  @Tool({
+    name: 'get_cash_balances',
+    description:
+      "Get the authenticated user's simulator cash balances, one entry per " +
+      'currency. A missing currency means a zero balance.',
+    parameters: z.object({}),
+  })
+  async getCashBalances(_args: unknown, _ctx: unknown, req: any) {
+    const user = requireUser(req);
+    const balances = await this.portfolio.getCashBalances(user.id);
+    return toolJson(balances.map(serializeCashBalance));
+  }
+
+  @Tool({
+    name: 'deposit_cash',
+    description:
+      'Deposit simulator cash into a currency balance. Buys are funded from ' +
+      'cash, so deposit before buying.',
+    parameters: z.object({
+      amount: z.number().min(0.01).describe('Amount to deposit (> 0).'),
+      currency: currency
+        .optional()
+        .describe('Currency of the balance. Defaults to USD.'),
+      note: z.string().trim().optional().describe('Optional free-text note.'),
+    }),
+  })
+  async depositCash(
+    args: { amount: number; currency?: string; note?: string },
+    _ctx: unknown,
+    req: any,
+  ) {
+    const user = requireUser(req);
+    return toolJson(
+      await this.portfolio.depositCash(user.id, {
+        amount: args.amount,
+        currency: args.currency,
+        note: args.note,
+      }),
+    );
+  }
+
+  @Tool({
+    name: 'withdraw_cash',
+    description:
+      'Withdraw simulator cash from a currency balance. Cannot go negative.',
+    parameters: z.object({
+      amount: z.number().min(0.01).describe('Amount to withdraw (> 0).'),
+      currency: currency
+        .optional()
+        .describe('Currency of the balance. Defaults to USD.'),
+      note: z.string().trim().optional().describe('Optional free-text note.'),
+    }),
+  })
+  async withdrawCash(
+    args: { amount: number; currency?: string; note?: string },
+    _ctx: unknown,
+    req: any,
+  ) {
+    const user = requireUser(req);
+    return toolJson(
+      await this.portfolio.withdrawCash(user.id, {
+        amount: args.amount,
+        currency: args.currency,
+        note: args.note,
+      }),
+    );
+  }
+
+  @Tool({
+    name: 'get_trade_history',
+    description:
+      "Get the authenticated user's trade history (buys and sells), most " +
+      'recent first. Optionally filter by symbol.',
+    parameters: z.object({
+      symbol: symbol.optional().describe('Optional symbol filter.'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .optional()
+        .describe('Max trades to return (default 100, max 500).'),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Number of trades to skip (pagination).'),
+    }),
+  })
+  async getTradeHistory(
+    args: { symbol?: string; limit?: number; offset?: number },
+    _ctx: unknown,
+    req: any,
+  ) {
+    const user = requireUser(req);
+    const trades = await this.portfolio.getTrades(user.id, {
+      symbol: args.symbol,
+      limit: args.limit,
+      offset: args.offset,
+    });
+    return toolJson(trades.map(serializePortfolioTrade));
+  }
+
+  @Tool({
+    name: 'get_portfolio_summary',
+    description:
+      'Net-worth summary for the authenticated user: market value of holdings ' +
+      'plus simulator cash. Optionally expressed in a chosen display currency.',
+    parameters: z.object({
+      displayCurrency: currency
+        .optional()
+        .describe('Optional currency to express the summary in.'),
+    }),
+  })
+  async getPortfolioSummary(
+    args: { displayCurrency?: string },
+    _ctx: unknown,
+    req: any,
+  ) {
+    const user = requireUser(req);
+    return toolJson(
+      await this.portfolio.getPortfolioSummary(user.id, args.displayCurrency),
+    );
+  }
+
+  @Tool({
+    name: 'record_trade',
+    description:
+      'Record an externally-executed trade (buy or sell) to consolidate ' +
+      'holdings from other apps into this portfolio. Permissive: it mirrors a ' +
+      'trade that already happened, so it does NOT require sufficient cash. ' +
+      'Idempotent on external_id — re-recording the same key returns the ' +
+      'original trade. Sells reduce the given position_id, else the oldest ' +
+      'matching lot (FIFO).',
+    parameters: z.object({
+      symbol,
+      side: z.enum(['buy', 'sell']).describe('Trade side.'),
+      shares: z.number().min(0.0001).describe('Number of shares.'),
+      price: z.number().min(0.0001).describe('Execution price per share.'),
+      trade_date: z
+        .string()
+        .trim()
+        .min(1)
+        .describe('Date the trade executed, YYYY-MM-DD.'),
+      currency: currency
+        .optional()
+        .describe('Trade currency. Auto-detected from the ticker if omitted.'),
+      fees: z.number().min(0).optional().describe('Transaction fees.'),
+      position_id: z
+        .string()
+        .trim()
+        .optional()
+        .describe('For sells: the lot to reduce. Defaults to FIFO.'),
+      source: z
+        .string()
+        .trim()
+        .optional()
+        .describe("Origin app name, e.g. 'robinhood'. Defaults to 'mcp'."),
+      external_id: z
+        .string()
+        .trim()
+        .optional()
+        .describe('Idempotency key from the source system.'),
+      note: z.string().trim().optional().describe('Optional free-text note.'),
+    }),
+  })
+  async recordTrade(
+    args: {
+      symbol: string;
+      side: 'buy' | 'sell';
+      shares: number;
+      price: number;
+      trade_date: string;
+      currency?: string;
+      fees?: number;
+      position_id?: string;
+      source?: string;
+      external_id?: string;
+      note?: string;
+    },
+    _ctx: unknown,
+    req: any,
+  ) {
+    const user = requireUser(req);
+    const result = await this.portfolio.recordTrade(user.id, {
+      symbol: args.symbol,
+      side: args.side,
+      shares: args.shares,
+      price: args.price,
+      trade_date: args.trade_date,
+      currency: args.currency,
+      fees: args.fees,
+      position_id: args.position_id,
+      source: args.source,
+      external_id: args.external_id,
+      note: args.note,
+    });
+    return toolJson({
+      trade: serializePortfolioTrade(result.trade),
+      idempotent: result.idempotent,
+    });
   }
 
   // ---- Watchlists ---------------------------------------------------------

--- a/src/modules/portfolio/dto/cash-operation.dto.ts
+++ b/src/modules/portfolio/dto/cash-operation.dto.ts
@@ -1,0 +1,36 @@
+import { IsNumber, Min, IsOptional, IsString, IsIn } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export const SUPPORTED_CURRENCIES = [
+  'USD',
+  'EUR',
+  'GBP',
+  'CHF',
+  'JPY',
+  'CAD',
+  'AUD',
+] as const;
+
+/** Deposit or withdraw simulator cash for a single currency. */
+export class CashOperationDto {
+  @ApiProperty({ example: 10000, description: 'Amount of cash to move (> 0).' })
+  @IsNumber()
+  @Min(0.01)
+  amount: number;
+
+  @ApiProperty({
+    example: 'USD',
+    description: 'Currency of the cash balance.',
+    required: false,
+    default: 'USD',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(SUPPORTED_CURRENCIES as unknown as string[])
+  currency?: string;
+
+  @ApiProperty({ required: false, description: 'Optional free-text note.' })
+  @IsOptional()
+  @IsString()
+  note?: string;
+}

--- a/src/modules/portfolio/dto/record-trade.dto.ts
+++ b/src/modules/portfolio/dto/record-trade.dto.ts
@@ -1,0 +1,98 @@
+import {
+  IsNumber,
+  IsDateString,
+  Min,
+  IsOptional,
+  IsString,
+  IsIn,
+  IsNotEmpty,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { SUPPORTED_CURRENCIES } from './cash-operation.dto';
+
+/**
+ * Generic trade record used to consolidate buys/sells imported from other
+ * applications (typically via MCP). Unlike the interactive add/sell flows this
+ * is permissive: it does NOT enforce sufficient cash (the trade already
+ * happened elsewhere), only mirrors its cash effect. `external_id` makes the
+ * import idempotent so the same external trade is never recorded twice.
+ */
+export class RecordTradeDto {
+  @ApiProperty({ example: 'AAPL', description: 'Ticker symbol.' })
+  @IsString()
+  @IsNotEmpty()
+  symbol: string;
+
+  @ApiProperty({ enum: ['buy', 'sell'], description: 'Trade side.' })
+  @IsString()
+  @IsIn(['buy', 'sell'])
+  side: 'buy' | 'sell';
+
+  @ApiProperty({ example: 5, description: 'Number of shares (>= 0.0001).' })
+  @IsNumber()
+  @Min(0.0001)
+  shares: number;
+
+  @ApiProperty({ example: 187.4, description: 'Execution price per share.' })
+  @IsNumber()
+  @Min(0.0001)
+  price: number;
+
+  @ApiProperty({
+    example: '2026-06-21',
+    description: 'Date the trade executed (YYYY-MM-DD).',
+  })
+  @IsDateString()
+  trade_date: string;
+
+  @ApiProperty({
+    example: 'USD',
+    required: false,
+    description: 'Trade currency. Auto-detected from the ticker if omitted.',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(SUPPORTED_CURRENCIES as unknown as string[])
+  currency?: string;
+
+  @ApiProperty({ required: false, description: 'Transaction fees.' })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  fees?: number;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'For sells: the lot/position id to reduce. If omitted, the oldest ' +
+      'matching open lot for the symbol is used (FIFO).',
+  })
+  @IsOptional()
+  @IsString()
+  position_id?: string;
+
+  @ApiProperty({
+    required: false,
+    example: 'robinhood',
+    description:
+      "Origin of the trade, e.g. the source app name. Defaults to 'mcp'.",
+  })
+  @IsOptional()
+  @IsString()
+  source?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Idempotency key from the source system. Re-recording the same ' +
+      'external_id is a no-op that returns the original trade.',
+  })
+  @IsOptional()
+  @IsString()
+  external_id?: string;
+
+  @ApiProperty({ required: false, description: 'Optional free-text note.' })
+  @IsOptional()
+  @IsString()
+  note?: string;
+}

--- a/src/modules/portfolio/dto/sell-position.dto.ts
+++ b/src/modules/portfolio/dto/sell-position.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsNumber,
+  IsDateString,
+  Min,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SellPositionDto {
+  @ApiProperty({
+    example: 5,
+    description: 'Number of shares to sell (>= 0.0001)',
+  })
+  @IsNumber()
+  @Min(0.0001)
+  shares: number;
+
+  @ApiProperty({ example: 512.3, description: 'Sale price per share' })
+  @IsNumber()
+  @Min(0.0001)
+  price: number;
+
+  @ApiProperty({
+    example: '2026-06-21',
+    description: 'Date of sale (YYYY-MM-DD). Defaults to today if omitted.',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString()
+  sell_date?: string;
+
+  @ApiProperty({
+    example: 1.0,
+    description: 'Optional transaction fees deducted from proceeds.',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  fees?: number;
+
+  @ApiProperty({ required: false, description: 'Optional free-text note.' })
+  @IsOptional()
+  @IsString()
+  note?: string;
+}

--- a/src/modules/portfolio/entities/portfolio-cash-balance.entity.ts
+++ b/src/modules/portfolio/entities/portfolio-cash-balance.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Materialized simulator cash balance, one row per (user, currency). Proceeds
+ * from sells and manual deposits credit it; strict buys and withdrawals debit
+ * it. Kept per-currency because positions are multi-currency — selling an EUR
+ * stock credits EUR cash, not USD.
+ *
+ * A missing row is treated as a zero balance everywhere, so users start at 0
+ * with no backfill needed.
+ */
+@Entity('portfolio_cash_balances')
+@Index(['user_id', 'currency'], { unique: true })
+export class PortfolioCashBalance {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  user_id: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ length: 3 })
+  currency: string;
+
+  @Column('decimal', { precision: 20, scale: 2, default: 0 })
+  amount: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
+}

--- a/src/modules/portfolio/entities/portfolio-trade.entity.ts
+++ b/src/modules/portfolio/entities/portfolio-trade.entity.ts
@@ -1,0 +1,97 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { PortfolioPosition } from './portfolio-position.entity';
+
+/**
+ * Append-only ledger of executed trades (buys and sells) for the trading
+ * simulator. This is the immutable history: "what I traded, how many, at what
+ * price, and when". Positions and cash balances are mutated alongside each
+ * trade, but trades themselves are never edited — they are the audit trail.
+ *
+ * `source` records where the trade originated ('app', 'mcp', or an external
+ * app name) so trades consolidated from other applications via MCP can be told
+ * apart. `external_id` is the idempotency key for those imports: a partial
+ * unique index on (user_id, external_id) lets `record_trade` be retried safely.
+ */
+@Entity('portfolio_trades')
+@Index(['user_id', 'symbol'])
+@Index(['user_id', 'trade_date'])
+export class PortfolioTrade {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  user_id: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  // The lot this trade affected. Kept nullable + ON DELETE SET NULL so the
+  // history survives when a position is fully sold/closed and its row removed.
+  @Column({ name: 'position_id', nullable: true })
+  position_id: string | null;
+
+  @ManyToOne(() => PortfolioPosition, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'position_id' })
+  position: PortfolioPosition | null;
+
+  @Column()
+  symbol: string;
+
+  @Column({ type: 'varchar', length: 4 })
+  side: 'buy' | 'sell';
+
+  @Column('decimal', { precision: 20, scale: 8 })
+  shares: number;
+
+  @Column('decimal', { precision: 20, scale: 8 })
+  price: number;
+
+  // Gross cash value of the trade (shares * price), before fees. Stored for
+  // cheap history rendering without re-multiplying decimals on the client.
+  @Column('decimal', { precision: 20, scale: 2, name: 'total_value' })
+  total_value: number;
+
+  @Column('decimal', { precision: 20, scale: 2, default: 0 })
+  fees: number;
+
+  // Realized profit/loss vs the lot's cost basis. Sells only; null for buys.
+  @Column('decimal', {
+    precision: 20,
+    scale: 2,
+    name: 'realized_pnl',
+    nullable: true,
+  })
+  realized_pnl: number | null;
+
+  @Column({ length: 3, default: 'USD' })
+  currency: string;
+
+  @Column({ type: 'date', name: 'trade_date' })
+  trade_date: string; // ISO date string YYYY-MM-DD
+
+  @Column({ length: 32, default: 'app' })
+  source: string;
+
+  @Column({ name: 'external_id', length: 128, nullable: true })
+  external_id: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  note: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
+}

--- a/src/modules/portfolio/entities/portfolio-trade.entity.ts
+++ b/src/modules/portfolio/entities/portfolio-trade.entity.ts
@@ -83,7 +83,10 @@ export class PortfolioTrade {
   @Column({ length: 32, default: 'app' })
   source: string;
 
-  @Column({ name: 'external_id', length: 128, nullable: true })
+  // Explicit `type` is required: a `string | null` union reflects as `Object`,
+  // which TypeORM rejects at startup ("Data type Object not supported"). Matches
+  // the migration's varchar(128).
+  @Column({ type: 'varchar', name: 'external_id', length: 128, nullable: true })
   external_id: string | null;
 
   @Column({ type: 'text', nullable: true })

--- a/src/modules/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio.controller.ts
@@ -14,6 +14,9 @@ import {
 import { PortfolioService } from './portfolio.service';
 import { CreatePortfolioPositionDto } from './dto/create-portfolio-position.dto';
 import { UpdatePortfolioPositionDto } from './dto/update-portfolio-position.dto';
+import { SellPositionDto } from './dto/sell-position.dto';
+import { CashOperationDto } from './dto/cash-operation.dto';
+import { RecordTradeDto } from './dto/record-trade.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CreditGuard } from '../research/guards/credit.guard';
 import { AuthenticatedRequest } from '../auth/interfaces/authenticated-request.interface';
@@ -66,6 +69,79 @@ export class PortfolioController {
   @ApiOperation({ summary: 'Remove a position' })
   remove(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
     return this.portfolioService.remove(req.user.id, id);
+  }
+
+  @Post('positions/:id/sell')
+  @ApiOperation({
+    summary: 'Sell shares of a position (credits cash, records realized P&L)',
+  })
+  sell(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Body() dto: SellPositionDto,
+  ) {
+    return this.portfolioService.sell(req.user.id, id, dto);
+  }
+
+  @Get('summary')
+  @ApiOperation({ summary: 'Net-worth summary: holdings + cash' })
+  @ApiQuery({ name: 'displayCurrency', required: false, example: 'EUR' })
+  getSummary(
+    @Req() req: AuthenticatedRequest,
+    @Query('displayCurrency') displayCurrency?: string,
+  ) {
+    return this.portfolioService.getPortfolioSummary(
+      req.user.id,
+      displayCurrency,
+    );
+  }
+
+  @Get('cash')
+  @ApiOperation({ summary: 'Get simulator cash balances per currency' })
+  getCash(@Req() req: AuthenticatedRequest) {
+    return this.portfolioService.getCashBalances(req.user.id);
+  }
+
+  @Post('cash/deposit')
+  @ApiOperation({ summary: 'Deposit simulator cash' })
+  depositCash(@Req() req: AuthenticatedRequest, @Body() dto: CashOperationDto) {
+    return this.portfolioService.depositCash(req.user.id, dto);
+  }
+
+  @Post('cash/withdraw')
+  @ApiOperation({ summary: 'Withdraw simulator cash' })
+  withdrawCash(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CashOperationDto,
+  ) {
+    return this.portfolioService.withdrawCash(req.user.id, dto);
+  }
+
+  @Get('trades')
+  @ApiOperation({ summary: 'Trade history (most recent first)' })
+  @ApiQuery({ name: 'symbol', required: false, example: 'AAPL' })
+  @ApiQuery({ name: 'limit', required: false, example: 100 })
+  @ApiQuery({ name: 'offset', required: false, example: 0 })
+  getTrades(
+    @Req() req: AuthenticatedRequest,
+    @Query('symbol') symbol?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.portfolioService.getTrades(req.user.id, {
+      symbol,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      offset: offset ? parseInt(offset, 10) : undefined,
+    });
+  }
+
+  @Post('trades')
+  @ApiOperation({
+    summary:
+      'Record an externally-executed trade for consolidation (idempotent)',
+  })
+  recordTrade(@Req() req: AuthenticatedRequest, @Body() dto: RecordTradeDto) {
+    return this.portfolioService.recordTrade(req.user.id, dto);
   }
 
   @UseGuards(CreditGuard)

--- a/src/modules/portfolio/portfolio.module.ts
+++ b/src/modules/portfolio/portfolio.module.ts
@@ -4,6 +4,8 @@ import { PortfolioService } from './portfolio.service';
 import { PortfolioController } from './portfolio.controller';
 import { PortfolioPosition } from './entities/portfolio-position.entity';
 import { PortfolioAnalysis } from './entities/portfolio-analysis.entity';
+import { PortfolioTrade } from './entities/portfolio-trade.entity';
+import { PortfolioCashBalance } from './entities/portfolio-cash-balance.entity';
 import { MarketDataModule } from '../market-data/market-data.module';
 import { LlmModule } from '../llm/llm.module';
 import { TickersModule } from '../tickers/tickers.module';
@@ -13,7 +15,12 @@ import { QuotaModule } from '../../common/quota/quota.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PortfolioPosition, PortfolioAnalysis]),
+    TypeOrmModule.forFeature([
+      PortfolioPosition,
+      PortfolioAnalysis,
+      PortfolioTrade,
+      PortfolioCashBalance,
+    ]),
     forwardRef(() => MarketDataModule),
     LlmModule,
     forwardRef(() => TickersModule),

--- a/src/modules/portfolio/portfolio.service.spec.ts
+++ b/src/modules/portfolio/portfolio.service.spec.ts
@@ -3,6 +3,8 @@ import { PortfolioService } from './portfolio.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PortfolioPosition } from './entities/portfolio-position.entity';
 import { PortfolioAnalysis } from './entities/portfolio-analysis.entity';
+import { PortfolioTrade } from './entities/portfolio-trade.entity';
+import { PortfolioCashBalance } from './entities/portfolio-cash-balance.entity';
 import { MarketDataService } from '../market-data/market-data.service';
 import { LlmService } from '../llm/llm.service';
 import { TickersService } from '../tickers/tickers.service';
@@ -35,11 +37,41 @@ const mockPositionRepo: any = {
   count: jest.fn().mockResolvedValue(0),
 };
 
-// create() serializes per-user inserts inside positionRepo.manager.transaction
-// (advisory lock + count-based quota check). The tx manager delegates back to
-// the same repo mock so create/save/count expectations are unchanged.
+// Cash balance repo. Default: a well-funded USD balance so strict buys pass.
+// Returns a fresh copy each call so the helper's in-place mutation of `amount`
+// doesn't leak between tests.
+const mockCashRow = {
+  id: 'cash-1',
+  user_id: 'user-1',
+  currency: 'USD',
+  amount: 100000,
+};
+const mockCashRepo: any = {
+  findOne: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve({ ...mockCashRow })),
+  create: jest.fn((d: any) => ({ ...d })),
+  save: jest.fn().mockImplementation((r: any) => Promise.resolve(r)),
+  find: jest.fn().mockResolvedValue([{ ...mockCashRow }]),
+};
+
+// Append-only trade ledger repo. Echoes back what it's told to save.
+const mockTradeRepo: any = {
+  create: jest.fn((d: any) => ({ id: 'trade-1', ...d })),
+  save: jest.fn().mockImplementation((r: any) => Promise.resolve(r)),
+  findOne: jest.fn().mockResolvedValue(null),
+  find: jest.fn().mockResolvedValue([]),
+};
+
+// create()/sell()/etc. run inside positionRepo.manager.transaction (advisory
+// lock + count-based quota + cash read-modify-write). The tx manager hands back
+// the repo mock matching the requested entity.
 const mockPositionTxManager = {
-  getRepository: jest.fn(() => mockPositionRepo),
+  getRepository: jest.fn((entity: any) => {
+    if (entity === PortfolioCashBalance) return mockCashRepo;
+    if (entity === PortfolioTrade) return mockTradeRepo;
+    return mockPositionRepo;
+  }),
   query: jest.fn().mockResolvedValue(undefined),
 };
 
@@ -47,6 +79,11 @@ mockPositionRepo.manager = {
   transaction: jest.fn((cb: (m: typeof mockPositionTxManager) => unknown) =>
     Promise.resolve(cb(mockPositionTxManager)),
   ),
+  getRepository: jest.fn((entity: any) => {
+    if (entity === PortfolioCashBalance) return mockCashRepo;
+    if (entity === PortfolioTrade) return mockTradeRepo;
+    return mockPositionRepo;
+  }),
 };
 
 const mockQuotaService = { assertWithinLimit: jest.fn() };
@@ -136,7 +173,7 @@ describe('PortfolioService', () => {
   });
 
   describe('create', () => {
-    it('should create a position', async () => {
+    it('should create a position when cash covers the cost', async () => {
       const dto = {
         symbol: 'NVDA',
         shares: 10,
@@ -146,6 +183,57 @@ describe('PortfolioService', () => {
       const result = await service.create('user-1', dto);
       expect(result).toEqual(mockPosition);
       expect(mockPositionRepo.save).toHaveBeenCalled();
+      // Strict simulator: cash is debited and a BUY trade is recorded.
+      expect(mockCashRepo.save).toHaveBeenCalled();
+      expect(mockTradeRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ side: 'buy', symbol: 'NVDA' }),
+      );
+    });
+
+    it('should reject a buy when cash is insufficient', async () => {
+      // Zero balance (no cash row) for this call only.
+      mockCashRepo.findOne.mockResolvedValueOnce(null);
+      const dto = {
+        symbol: 'NVDA',
+        shares: 10,
+        buy_price: 100,
+        buy_date: '2024-01-01',
+      };
+      await expect(service.create('user-1', dto)).rejects.toThrow(
+        /Insufficient/,
+      );
+    });
+  });
+
+  describe('sell', () => {
+    it('should book realized P&L and credit proceeds to cash', async () => {
+      // Sell 5 of 10 NVDA @ 150 (bought @ 100): proceeds 750, P&L +250.
+      mockPositionRepo.findOne.mockResolvedValueOnce({
+        ...mockPosition,
+        shares: 10,
+        buy_price: 100,
+        currency: 'USD',
+      });
+      const result = await service.sell('user-1', 'uuid-1', {
+        shares: 5,
+        price: 150,
+      });
+      expect(result.proceeds).toBe(750);
+      expect(result.realized_pnl).toBe(250);
+      expect(result.cash_balance.amount).toBe(100750); // 100000 + 750
+      expect(mockTradeRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ side: 'sell' }),
+      );
+    });
+
+    it('should reject selling more shares than held', async () => {
+      mockPositionRepo.findOne.mockResolvedValueOnce({
+        ...mockPosition,
+        shares: 3,
+      });
+      await expect(
+        service.sell('user-1', 'uuid-1', { shares: 5, price: 150 }),
+      ).rejects.toThrow(/Cannot sell/);
     });
   });
 

--- a/src/modules/portfolio/portfolio.service.ts
+++ b/src/modules/portfolio/portfolio.service.ts
@@ -1,17 +1,23 @@
 import {
   Injectable,
   NotFoundException,
+  BadRequestException,
   Inject,
   forwardRef,
   OnModuleInit,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, EntityManager } from 'typeorm';
 import { PortfolioPosition } from './entities/portfolio-position.entity';
 import { PortfolioAnalysis } from './entities/portfolio-analysis.entity';
+import { PortfolioTrade } from './entities/portfolio-trade.entity';
+import { PortfolioCashBalance } from './entities/portfolio-cash-balance.entity';
 import { CreatePortfolioPositionDto } from './dto/create-portfolio-position.dto';
 import { UpdatePortfolioPositionDto } from './dto/update-portfolio-position.dto';
+import { SellPositionDto } from './dto/sell-position.dto';
+import { CashOperationDto } from './dto/cash-operation.dto';
+import { RecordTradeDto } from './dto/record-trade.dto';
 import { MarketDataService } from '../market-data/market-data.service';
 import { LlmService } from '../llm/llm.service';
 import { TickersService } from '../tickers/tickers.service';
@@ -48,21 +54,24 @@ export class PortfolioService implements OnModuleInit {
     );
   }
 
+  /**
+   * Buy a position. This is the STRICT simulator path: the buy must be funded
+   * by simulator cash in the same currency, which is deducted atomically. New
+   * users start at a zero balance, so a buy requires depositing cash first.
+   * Every buy is mirrored into the append-only trade ledger.
+   */
   async create(
     userId: string,
     dto: CreatePortfolioPositionDto,
   ): Promise<PortfolioPosition> {
     // Auto-detect currency from ticker if not explicitly provided (read-only,
     // safe to resolve before taking the per-user lock).
-    let currency = dto.currency;
-    if (!currency) {
-      const ticker = await this.tickersService.findOneBySymbol(dto.symbol);
-      currency = ticker?.currency || 'USD';
-    }
+    const currency = await this.resolveCurrency(dto.symbol, dto.currency);
 
     // Serialize concurrent creates for THIS user inside a transaction. Without
     // the advisory lock, two parallel requests could both pass the count-based
-    // quota check before either inserts, letting the user exceed their limit.
+    // quota check before either inserts, letting the user exceed their limit;
+    // it also serializes the read-modify-write on the cash balance.
     return this.positionRepo.manager.transaction(async (tx) => {
       await tx.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
         `portfolio:${userId}`,
@@ -72,13 +81,464 @@ export class PortfolioService implements OnModuleInit {
       const count = await repo.count({ where: { user_id: userId } });
       await this.quota.assertWithinLimit(userId, 'portfolioPositions', count);
 
+      // Deduct the cost from cash first — throws if the user can't afford it,
+      // aborting the transaction before any position/trade is written.
+      const cost = this.round2(dto.shares * dto.buy_price);
+      await this.adjustCashTx(tx, userId, currency, -cost, { enforce: true });
+
       const position = repo.create({
         ...dto,
         currency,
         user_id: userId,
       });
-      return repo.save(position);
+      const saved = await repo.save(position);
+
+      await this.insertTradeTx(tx, {
+        userId,
+        positionId: saved.id,
+        symbol: saved.symbol,
+        side: 'buy',
+        shares: dto.shares,
+        price: dto.buy_price,
+        currency,
+        tradeDate: dto.buy_date,
+        source: 'app',
+      });
+
+      return saved;
     });
+  }
+
+  /**
+   * Sell shares of an existing position. Reduces (or closes) the lot, books the
+   * realized P&L, credits the proceeds (gross − fees) to the cash balance, and
+   * records a SELL trade. Selling more than is held is rejected.
+   */
+  async sell(
+    userId: string,
+    positionId: string,
+    dto: SellPositionDto,
+  ): Promise<{
+    position: PortfolioPosition | null;
+    trade: PortfolioTrade;
+    proceeds: number;
+    realized_pnl: number;
+    cash_balance: { currency: string; amount: number };
+  }> {
+    return this.positionRepo.manager.transaction(async (tx) => {
+      await tx.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        `portfolio:${userId}`,
+      ]);
+
+      const repo = tx.getRepository(PortfolioPosition);
+      const position = await repo.findOne({
+        where: { id: positionId, user_id: userId },
+      });
+      if (!position) {
+        throw new NotFoundException('Position not found');
+      }
+
+      const held = Number(position.shares);
+      const sharesToSell = dto.shares;
+      // Tiny epsilon so floating-point representation of a "sell all" doesn't trip.
+      if (sharesToSell > held + 1e-9) {
+        throw new BadRequestException(
+          `Cannot sell ${sharesToSell} shares; only ${held} held.`,
+        );
+      }
+
+      const price = dto.price;
+      const fees = dto.fees ?? 0;
+      const currency = position.currency || 'USD';
+      const gross = this.round2(sharesToSell * price);
+      const proceeds = this.round2(gross - fees);
+      const costBasis = this.round2(sharesToSell * Number(position.buy_price));
+      const realizedPnl = this.round2(proceeds - costBasis);
+      const sellDate = dto.sell_date || this.todayIso();
+
+      // Reduce or close the lot. A full sell deletes the row; the SELL trade is
+      // kept (FK is ON DELETE SET NULL), so history survives.
+      const remaining = this.round2(held - sharesToSell);
+      let updatedPosition: PortfolioPosition | null;
+      let tradePositionId: string | null;
+      if (remaining <= 0) {
+        await repo.remove(position);
+        updatedPosition = null;
+        tradePositionId = null;
+      } else {
+        position.shares = remaining;
+        updatedPosition = await repo.save(position);
+        tradePositionId = position.id;
+      }
+
+      const trade = await this.insertTradeTx(tx, {
+        userId,
+        positionId: tradePositionId,
+        symbol: position.symbol,
+        side: 'sell',
+        shares: sharesToSell,
+        price,
+        fees,
+        realizedPnl,
+        currency,
+        tradeDate: sellDate,
+        source: 'app',
+        note: dto.note,
+      });
+
+      const cashAfter = await this.adjustCashTx(
+        tx,
+        userId,
+        currency,
+        proceeds,
+        { enforce: false },
+      );
+
+      return {
+        position: updatedPosition,
+        trade,
+        proceeds,
+        realized_pnl: realizedPnl,
+        cash_balance: { currency, amount: cashAfter },
+      };
+    });
+  }
+
+  /** Current simulator cash balances, one entry per currency (zero rows omitted). */
+  async getCashBalances(
+    userId: string,
+  ): Promise<{ currency: string; amount: number }[]> {
+    const repo = this.positionRepo.manager.getRepository(PortfolioCashBalance);
+    const rows = await repo.find({
+      where: { user_id: userId },
+      order: { currency: 'ASC' },
+    });
+    return rows.map((r) => ({
+      currency: r.currency,
+      amount: Number(r.amount),
+    }));
+  }
+
+  /** Add simulator cash to a currency balance. */
+  async depositCash(
+    userId: string,
+    dto: CashOperationDto,
+  ): Promise<{ currency: string; amount: number }> {
+    const currency = dto.currency || 'USD';
+    return this.positionRepo.manager.transaction(async (tx) => {
+      await tx.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        `portfolio:${userId}`,
+      ]);
+      const amount = await this.adjustCashTx(
+        tx,
+        userId,
+        currency,
+        this.round2(dto.amount),
+        { enforce: false },
+      );
+      return { currency, amount };
+    });
+  }
+
+  /** Withdraw simulator cash from a currency balance (cannot go negative). */
+  async withdrawCash(
+    userId: string,
+    dto: CashOperationDto,
+  ): Promise<{ currency: string; amount: number }> {
+    const currency = dto.currency || 'USD';
+    return this.positionRepo.manager.transaction(async (tx) => {
+      await tx.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        `portfolio:${userId}`,
+      ]);
+      const amount = await this.adjustCashTx(
+        tx,
+        userId,
+        currency,
+        -this.round2(dto.amount),
+        { enforce: true },
+      );
+      return { currency, amount };
+    });
+  }
+
+  /** Trade history (most recent first), optionally filtered to one symbol. */
+  async getTrades(
+    userId: string,
+    opts?: { symbol?: string; limit?: number; offset?: number },
+  ): Promise<PortfolioTrade[]> {
+    const repo = this.positionRepo.manager.getRepository(PortfolioTrade);
+    const where: Record<string, unknown> = { user_id: userId };
+    if (opts?.symbol) where.symbol = opts.symbol.toUpperCase();
+    return repo.find({
+      where,
+      order: { trade_date: 'DESC', created_at: 'DESC' },
+      take: Math.min(opts?.limit ?? 100, 500),
+      skip: opts?.offset ?? 0,
+    });
+  }
+
+  /**
+   * Record an externally-executed trade for consolidation (typically via MCP).
+   * Permissive by design — it mirrors a trade that already happened elsewhere,
+   * so it does NOT enforce sufficient cash; buys may drive the balance negative.
+   * Idempotent on `external_id`: re-recording the same key returns the original
+   * trade untouched. Sells reduce the given lot, or the oldest matching lot
+   * (FIFO) when no `position_id` is supplied; a sell with no matching lot is
+   * still recorded as a pure ledger/cash entry.
+   */
+  async recordTrade(
+    userId: string,
+    dto: RecordTradeDto,
+  ): Promise<{ trade: PortfolioTrade; idempotent: boolean }> {
+    const symbol = dto.symbol.toUpperCase();
+    const currency = await this.resolveCurrency(symbol, dto.currency);
+    const source = dto.source || 'mcp';
+    const fees = dto.fees ?? 0;
+
+    return this.positionRepo.manager.transaction(async (tx) => {
+      await tx.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        `portfolio:${userId}`,
+      ]);
+
+      // Idempotency: a previously-imported external_id is a no-op.
+      if (dto.external_id) {
+        const existing = await tx.getRepository(PortfolioTrade).findOne({
+          where: { user_id: userId, external_id: dto.external_id },
+        });
+        if (existing) return { trade: existing, idempotent: true };
+      }
+
+      const posRepo = tx.getRepository(PortfolioPosition);
+
+      if (dto.side === 'buy') {
+        // Cash mirror (allowed to go negative) + open a new lot.
+        const cost = this.round2(dto.shares * dto.price + fees);
+        await this.adjustCashTx(tx, userId, currency, -cost, {
+          enforce: false,
+        });
+        const position = posRepo.create({
+          user_id: userId,
+          symbol,
+          shares: dto.shares,
+          buy_price: dto.price,
+          buy_date: dto.trade_date,
+          currency,
+        });
+        const saved = await posRepo.save(position);
+        const trade = await this.insertTradeTx(tx, {
+          userId,
+          positionId: saved.id,
+          symbol,
+          side: 'buy',
+          shares: dto.shares,
+          price: dto.price,
+          fees,
+          currency,
+          tradeDate: dto.trade_date,
+          source,
+          externalId: dto.external_id,
+          note: dto.note,
+        });
+        return { trade, idempotent: false };
+      }
+
+      // side === 'sell'
+      let position: PortfolioPosition | null = null;
+      if (dto.position_id) {
+        position = await posRepo.findOne({
+          where: { id: dto.position_id, user_id: userId },
+        });
+        if (!position) throw new NotFoundException('Position not found');
+      } else {
+        position = await posRepo.findOne({
+          where: { user_id: userId, symbol },
+          order: { buy_date: 'ASC' },
+        });
+      }
+
+      let realizedPnl: number | null = null;
+      let tradePositionId: string | null = null;
+      if (position) {
+        const held = Number(position.shares);
+        const sell = Math.min(dto.shares, held);
+        const costBasis = this.round2(sell * Number(position.buy_price));
+        const proceedsForLot = this.round2(sell * dto.price);
+        realizedPnl = this.round2(proceedsForLot - costBasis);
+        const remaining = this.round2(held - sell);
+        if (remaining <= 0) {
+          await posRepo.remove(position);
+          tradePositionId = null;
+        } else {
+          position.shares = remaining;
+          await posRepo.save(position);
+          tradePositionId = position.id;
+        }
+      }
+
+      const proceeds = this.round2(dto.shares * dto.price - fees);
+      await this.adjustCashTx(tx, userId, currency, proceeds, {
+        enforce: false,
+      });
+      const trade = await this.insertTradeTx(tx, {
+        userId,
+        positionId: tradePositionId,
+        symbol,
+        side: 'sell',
+        shares: dto.shares,
+        price: dto.price,
+        fees,
+        realizedPnl,
+        currency,
+        tradeDate: dto.trade_date,
+        source,
+        externalId: dto.external_id,
+        note: dto.note,
+      });
+      return { trade, idempotent: false };
+    });
+  }
+
+  /**
+   * Net-worth summary: market value of holdings + simulator cash, in an optional
+   * display currency. Holdings value is reused from findAll (already converted);
+   * cash is converted best-effort (native amount kept if no FX rate is available).
+   */
+  async getPortfolioSummary(
+    userId: string,
+    displayCurrency?: string,
+  ): Promise<{
+    currency: string;
+    holdings_value: number;
+    cash_value: number;
+    net_worth: number;
+    positions_count: number;
+    cash_balances: { currency: string; amount: number }[];
+  }> {
+    const positions = await this.findAll(userId, displayCurrency);
+    const holdingsValue = positions.reduce(
+      (sum, p) => sum + (Number(p.current_value) || 0),
+      0,
+    );
+
+    const cash = await this.getCashBalances(userId);
+    let cashValue = 0;
+    for (const c of cash) {
+      if (displayCurrency && c.currency !== displayCurrency) {
+        const rate = await this.currencyService.getRate(
+          c.currency,
+          displayCurrency,
+        );
+        cashValue += rate != null ? c.amount * rate : c.amount;
+      } else {
+        cashValue += c.amount;
+      }
+    }
+
+    const currency = displayCurrency || positions[0]?.currency || 'USD';
+    return {
+      currency,
+      holdings_value: this.round2(holdingsValue),
+      cash_value: this.round2(cashValue),
+      net_worth: this.round2(holdingsValue + cashValue),
+      positions_count: positions.length,
+      cash_balances: cash,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trading-simulator internals
+  // ---------------------------------------------------------------------------
+
+  /** Round to 2 decimals, avoiding binary-float drift on .005 boundaries. */
+  private round2(n: number): number {
+    return Math.round((n + Number.EPSILON) * 100) / 100;
+  }
+
+  /** Today's date as YYYY-MM-DD (the column type is a plain date). */
+  private todayIso(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  /** Resolve a trade currency: explicit value wins, else the ticker's native currency. */
+  private async resolveCurrency(
+    symbol: string,
+    explicit?: string,
+  ): Promise<string> {
+    if (explicit) return explicit;
+    const ticker = await this.tickersService.findOneBySymbol(symbol);
+    return ticker?.currency || 'USD';
+  }
+
+  /**
+   * Apply a signed delta to a (user, currency) cash balance inside a transaction
+   * and return the new amount. Find-or-create then mutate; the caller must hold
+   * the per-user advisory lock so this read-modify-write is race-free. With
+   * `enforce`, a resulting negative balance is rejected.
+   */
+  private async adjustCashTx(
+    tx: EntityManager,
+    userId: string,
+    currency: string,
+    delta: number,
+    opts: { enforce: boolean },
+  ): Promise<number> {
+    const repo = tx.getRepository(PortfolioCashBalance);
+    let row = await repo.findOne({
+      where: { user_id: userId, currency },
+    });
+    if (!row) {
+      row = repo.create({ user_id: userId, currency, amount: 0 });
+    }
+    const current = Number(row.amount);
+    const next = this.round2(current + delta);
+    if (opts.enforce && next < 0) {
+      throw new BadRequestException(
+        `Insufficient ${currency} cash: need ${Math.abs(delta).toFixed(2)}, ` +
+          `have ${current.toFixed(2)}. Deposit cash first.`,
+      );
+    }
+    row.amount = next;
+    await repo.save(row);
+    return next;
+  }
+
+  /** Insert an append-only trade-ledger row inside a transaction. */
+  private async insertTradeTx(
+    tx: EntityManager,
+    t: {
+      userId: string;
+      positionId?: string | null;
+      symbol: string;
+      side: 'buy' | 'sell';
+      shares: number;
+      price: number;
+      fees?: number;
+      realizedPnl?: number | null;
+      currency: string;
+      tradeDate: string;
+      source?: string;
+      externalId?: string | null;
+      note?: string | null;
+    },
+  ): Promise<PortfolioTrade> {
+    const repo = tx.getRepository(PortfolioTrade);
+    const trade = repo.create({
+      user_id: t.userId,
+      position_id: t.positionId ?? null,
+      symbol: t.symbol,
+      side: t.side,
+      shares: t.shares,
+      price: t.price,
+      total_value: this.round2(t.shares * t.price),
+      fees: t.fees ?? 0,
+      realized_pnl: t.realizedPnl ?? null,
+      currency: t.currency,
+      trade_date: t.tradeDate,
+      source: t.source ?? 'app',
+      external_id: t.externalId ?? null,
+      note: t.note ?? null,
+    });
+    return repo.save(trade);
   }
 
   async findAll(userId: string, displayCurrency?: string): Promise<any[]> {

--- a/src/modules/tickers/tickers.service.spec.ts
+++ b/src/modules/tickers/tickers.service.spec.ts
@@ -254,6 +254,11 @@ describe('TickersService', () => {
         {
           responseType: 'arraybuffer',
           maxRedirects: 0,
+          headers: {
+            'User-Agent':
+              'neural-ticker-logo-fetcher/1.0 (+https://neuralticker.com)',
+          },
+          timeout: 10000,
         },
       );
       expect(mockLogoRepo.create).toHaveBeenCalled();

--- a/src/modules/tickers/tickers.service.ts
+++ b/src/modules/tickers/tickers.service.ts
@@ -293,6 +293,15 @@ export class TickersService {
         this.httpService.get(url, {
           responseType: 'arraybuffer',
           maxRedirects: 0,
+          // Some image hosts reject a blank/default library User-Agent with
+          // HTTP 403 — notably Wikimedia/Wikipedia, a common source of company
+          // logos ("Please set a user-agent..."). Send a descriptive UA so the
+          // fetch is accepted. maxRedirects stays 0 so the SSRF host check
+          // above can't be bypassed via a redirect to a private address.
+          headers: {
+            'User-Agent': 'neural-ticker-logo-fetcher/1.0 (+https://neuralticker.com)',
+          },
+          timeout: 10000,
         }),
       );
 

--- a/test/mcp.e2e-spec.ts
+++ b/test/mcp.e2e-spec.ts
@@ -138,6 +138,43 @@ const mockPortfolio = {
   remove: jest.fn(() => Promise.resolve(undefined)),
   analyzePortfolio: jest.fn(() => Promise.resolve('# Analysis\nLooks good.')),
   getQuickRecommendation: jest.fn(() => Promise.resolve({ action: 'hold' })),
+  sell: jest.fn((_userId: string, id: string, dto: any) =>
+    Promise.resolve({
+      position: { id, symbol: 'AAPL', shares: 5 },
+      trade: { id: 't1', side: 'sell', symbol: 'AAPL', ...dto },
+      proceeds: 750,
+      realized_pnl: 250,
+      cash_balance: { currency: 'USD', amount: 750 },
+    }),
+  ),
+  getCashBalances: jest.fn(() =>
+    Promise.resolve([{ currency: 'USD', amount: 1000 }]),
+  ),
+  depositCash: jest.fn((_userId: string, dto: any) =>
+    Promise.resolve({ currency: dto.currency || 'USD', amount: dto.amount }),
+  ),
+  withdrawCash: jest.fn((_userId: string, dto: any) =>
+    Promise.resolve({ currency: dto.currency || 'USD', amount: 0 }),
+  ),
+  getTrades: jest.fn(() =>
+    Promise.resolve([{ id: 't1', symbol: 'AAPL', side: 'buy', shares: 5 }]),
+  ),
+  getPortfolioSummary: jest.fn(() =>
+    Promise.resolve({
+      currency: 'USD',
+      holdings_value: 1500,
+      cash_value: 1000,
+      net_worth: 2500,
+      positions_count: 1,
+      cash_balances: [{ currency: 'USD', amount: 1000 }],
+    }),
+  ),
+  recordTrade: jest.fn((_userId: string, dto: any) =>
+    Promise.resolve({
+      trade: { id: 't2', ...dto },
+      idempotent: false,
+    }),
+  ),
 };
 const mockWatchlist = {
   getUserWatchlists: jest.fn(() =>
@@ -246,6 +283,14 @@ const EXPECTED_TOOLS = [
   'remove_portfolio_position',
   'analyze_portfolio',
   'get_portfolio_recommendation',
+  // trading simulator (sell, cash, trade history, consolidation)
+  'sell_portfolio_position',
+  'get_cash_balances',
+  'deposit_cash',
+  'withdraw_cash',
+  'get_trade_history',
+  'get_portfolio_summary',
+  'record_trade',
   // watchlist
   'get_watchlists',
   'create_watchlist',
@@ -349,6 +394,51 @@ describe('MCP endpoint (e2e, mocked services)', () => {
     const payload = JSON.parse(res.result.content[0].text);
     expect(payload[0].userId).toBe('user-1');
     expect(mockPortfolio.findAll).toHaveBeenCalledWith('user-1', undefined);
+  });
+
+  it('sells a position via the trading-simulator tool', async () => {
+    const res = await call(
+      'sell_portfolio_position',
+      { id: 'p1', shares: 5, price: 150 },
+      { 'x-test-user-id': 'user-1' },
+    );
+    expect(res.result?.isError).toBeFalsy();
+    const payload = JSON.parse(res.result.content[0].text);
+    expect(payload.proceeds).toBe(750);
+    expect(payload.realized_pnl).toBe(250);
+    expect(mockPortfolio.sell).toHaveBeenCalledWith(
+      'user-1',
+      'p1',
+      expect.objectContaining({ shares: 5, price: 150 }),
+    );
+  });
+
+  it('records an external trade for consolidation and upper-cases the symbol', async () => {
+    const res = await call(
+      'record_trade',
+      {
+        symbol: 'aapl',
+        side: 'buy',
+        shares: 3,
+        price: 100,
+        trade_date: '2026-06-21',
+        external_id: 'robinhood:abc',
+      },
+      { 'x-test-user-id': 'user-1' },
+    );
+    expect(res.result?.isError).toBeFalsy();
+    const payload = JSON.parse(res.result.content[0].text);
+    expect(payload.idempotent).toBe(false);
+    expect(mockPortfolio.recordTrade).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ symbol: 'AAPL', external_id: 'robinhood:abc' }),
+    );
+  });
+
+  it('rejects trading-simulator tools when anonymous', async () => {
+    const res = await call('get_cash_balances', {});
+    expect(res.result?.isError).toBe(true);
+    expect(res.result.content[0].text).toContain('Authentication required');
   });
 
   it('charges credits exactly once for create_research', async () => {


### PR DESCRIPTION
## Summary

Follow-up work on top of #186 (in-process MCP server), which was **squash-merged** into `main`. This branch was cut fresh from `main` and contains **only the 5 commits made after that merge** — so the diff is the genuinely new work, not a re-show of #186.

### What's here
- **Trading simulator — backend.** Sell, cash deposit/withdraw, and an append-only trade ledger. Adds the `AddTradingSimulator` migration, `portfolio_trades` + `portfolio_cash_balance` entities, and `sell-position` / `cash-operation` / `record-trade` DTOs.
- **Trading simulator — frontend.** `CashDialog`, `SellPositionDialog`, `TradeHistoryDialog` plus wiring in the portfolio table / grid / stats.
- **Admin logo-manager MCP tools.** `list_ticker_logos` (mirrors the admin panel's "Show Missing Logos Only" filter) and `set_ticker_logo` (SSRF-guarded; stores `logo_url`, background-downloads & caches the image served at `GET /api/v1/tickers/:symbol/logo`). Brings the MCP tool count to 33.
- **frontend-v2 gating.** `/v2` is gated behind `FRONTEND_V2_ENABLED`.
- **Boot-blocker fix.** `PortfolioTrade.external_id` was typed `string | null` with no explicit column type, which TypeORM reflects as `Object` and rejects at startup (*"Data type Object not supported"*). Pinned to `varchar(128)` to match the migration — without this the app fails to boot on a clean build.

### Verification
- App boots cleanly with the entity fix: full Nest bootstrap, every route mapped (incl. `/api/mcp`), MCP registry discovers all tools.
- Logo MCP tools exercised end-to-end on the dev DB — sourced 4 real company logos (Airbus, Jenoptik, Ørsted, Vestas) via Wikidata P154 → Wikimedia Commons, set them with `set_ticker_logo`, and confirmed each was cached as `image/png` in `ticker_logos` **and** served HTTP 200 from `/api/v1/tickers/:symbol/logo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
