### PR TITLE
Centralize ticker icon URL & add app-fallback

### DIFF
--- a/src/modules/research/research.service.ts
+++ b/src/modules/research/research.service.ts
@@ -388,8 +388,7 @@ You MUST include a "Risk/Reward Profile" section at the end of your report with 
           );
 
         // 6b. Web push for creator
-        const frontendUrl = this.config.get<string>('frontendUrl') ?? '';
-        const tickerIconUrl = `${frontendUrl}/v1/tickers/${tickerSymbol}/logo`;
+        const tickerIconUrl = this.webPushService.tickerIconUrl(tickerSymbol);
         this.webPushService
           .sendToUser(note.user_id, {
             title: `Research Ready: ${note.tickers.join(', ')}`,

--- a/src/modules/social/social.service.spec.ts
+++ b/src/modules/social/social.service.spec.ts
@@ -77,6 +77,9 @@ describe('SocialService', () => {
 
   const mockWebPushService = {
     sendToUser: jest.fn().mockResolvedValue(undefined),
+    tickerIconUrl: jest.fn(
+      (symbol: string) => `/api/v1/tickers/${symbol}/logo?fallback=app`,
+    ),
   };
 
   const mockUsersService = {

--- a/src/modules/social/social.service.ts
+++ b/src/modules/social/social.service.ts
@@ -153,8 +153,6 @@ export class SocialService {
       relations: ['user'],
     });
 
-    const frontendUrl = this.configService.get<string>('frontendUrl') ?? '';
-
     // If this is a reply, notify the parent comment author
     if (parentId) {
       const parent = await this.commentRepo.findOne({
@@ -188,7 +186,7 @@ export class SocialService {
           .sendToUser(parent.user_id, {
             title: `${replierName} replied to your comment`,
             body: `on ${symbol}: "${content.slice(0, 80)}"`,
-            icon: `${frontendUrl}/v1/tickers/${symbol}/logo`,
+            icon: this.webPushService.tickerIconUrl(symbol),
             data: { url: `/ticker/${symbol}`, symbol },
           })
           .catch((err) =>
@@ -232,7 +230,7 @@ export class SocialService {
           .sendToUser(mentionedId, {
             title: `${commenterName} mentioned you`,
             body: `on ${symbol}`,
-            icon: `${frontendUrl}/v1/tickers/${symbol}/logo`,
+            icon: this.webPushService.tickerIconUrl(symbol),
             data: { url: `/ticker/${symbol}`, symbol },
           })
           .catch((err) =>
@@ -304,12 +302,11 @@ export class SocialService {
             this.logger.error(`Failed to send like notification`, err),
           );
 
-        const frontendUrl = this.configService.get<string>('frontendUrl') ?? '';
         this.webPushService
           .sendToUser(comment.user_id, {
             title: `${likerName} liked your comment`,
             body: `on ${comment.ticker_symbol}`,
-            icon: `${frontendUrl}/v1/tickers/${comment.ticker_symbol}/logo`,
+            icon: this.webPushService.tickerIconUrl(comment.ticker_symbol),
             data: {
               url: `/ticker/${comment.ticker_symbol}`,
               symbol: comment.ticker_symbol,

--- a/src/modules/tickers/tickers.controller.spec.ts
+++ b/src/modules/tickers/tickers.controller.spec.ts
@@ -107,12 +107,37 @@ describe('TickersController', () => {
         set: jest.fn(),
         send: jest.fn(),
         status: jest.fn().mockReturnThis(),
+        redirect: jest.fn(),
       };
 
       await controller.getLogo({} as any, 'UNKNOWN', res as any);
 
       expect(res.status).toHaveBeenCalledWith(404);
       expect(res.send).toHaveBeenCalledWith('Logo not found');
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the app favicon when logo missing and fallback=app (push icon)', async () => {
+      // Push notifications request `?fallback=app` so a logo-less ticker still
+      // shows the branded favicon instead of the OS grey placeholder.
+      mockTickersService.getLogo.mockResolvedValue(null);
+
+      const res = {
+        set: jest.fn(),
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        redirect: jest.fn(),
+      };
+
+      await controller.getLogo(
+        { query: { fallback: 'app' } } as any,
+        'EKT.DE',
+        res as any,
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith('/favicon.svg');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'no-store');
+      expect(res.status).not.toHaveBeenCalledWith(404);
     });
   });
 

--- a/src/modules/tickers/tickers.controller.ts
+++ b/src/modules/tickers/tickers.controller.ts
@@ -244,6 +244,18 @@ export class TickersController {
     const isAdmin = req.user?.role === 'admin';
     const logo = await this.tickersService.getLogo(symbol, isAdmin);
     if (!logo) {
+      // Push-notification icons request this endpoint with `?fallback=app`. A
+      // ticker with no stored logo (e.g. a custom symbol) would otherwise 404,
+      // and a push icon has no client-side onError hook — the OS just renders
+      // its grey app-letter placeholder. Redirect to the app favicon instead so
+      // the notification still shows a branded icon. The redirect is
+      // root-relative, so the client resolves it against the request origin (the
+      // public frontend, which serves /favicon.svg). In-app <img> consumers do
+      // NOT pass the flag and keep their own initials placeholder.
+      if (req.query?.fallback === 'app') {
+        res.set('Cache-Control', 'no-store');
+        return res.redirect('/favicon.svg');
+      }
       return res.status(404).send('Logo not found');
     }
 

--- a/src/modules/web-push/web-push.service.spec.ts
+++ b/src/modules/web-push/web-push.service.spec.ts
@@ -364,6 +364,28 @@ describe('WebPushService', () => {
     });
   });
 
+  describe('tickerIconUrl', () => {
+    it('builds the root-relative /api/v1 logo URL with the app fallback flag', async () => {
+      // Regression: this URL was previously built as `/v1/tickers/...` (missing
+      // the global `api` prefix), which 404'd and forced Android to fall back to
+      // its grey app-letter icon instead of the logo. It is root-relative so the
+      // service worker resolves it against the frontend origin.
+      service = await buildModule({ frontendUrl: 'https://neuralticker.com' });
+
+      expect(service.tickerIconUrl('AAPL')).toBe(
+        '/api/v1/tickers/AAPL/logo?fallback=app',
+      );
+    });
+
+    it('encodes the symbol', async () => {
+      service = await buildModule({});
+
+      expect(service.tickerIconUrl('BRK B')).toBe(
+        '/api/v1/tickers/BRK%20B/logo?fallback=app',
+      );
+    });
+  });
+
   describe('getPublicKey', () => {
     it('should return the VAPID public key', async () => {
       service = await buildModule({ VAPID_PUBLIC_KEY: 'my-pub-key' });

--- a/src/modules/web-push/web-push.service.ts
+++ b/src/modules/web-push/web-push.service.ts
@@ -180,4 +180,30 @@ export class WebPushService {
   getPublicKey(): string {
     return this.configService.get<string>('VAPID_PUBLIC_KEY', '');
   }
+
+  /**
+   * Build the notification `icon` URL for a ticker's logo.
+   *
+   * Centralised here because this URL was twice hand-built with the WRONG path
+   * (`/v1/tickers/...`) — the global `api` prefix was omitted, so it must be
+   * `/api/v1/tickers/...` (the controller is `@Controller('v1/tickers')` behind
+   * `app.setGlobalPrefix('api')`; the frontend's own logo hook uses `/api/v1`).
+   * The bad URL 404'd, so Android dropped the logo and rendered its generic grey
+   * app-letter icon instead.
+   *
+   * Returned ROOT-RELATIVE on purpose: the service worker resolves a relative
+   * `icon` against its own (frontend) origin, which reverse-proxies `/api` to
+   * the backend and serves `/favicon.svg` directly. This mirrors the
+   * already-working price-alert icon (`/favicon.svg`) and the frontend API
+   * client (`baseURL: '/api/v1'`), and avoids depending on FRONTEND_URL — which
+   * may be unset or a comma-separated apex+www list that would corrupt an
+   * absolute URL.
+   *
+   * `?fallback=app` tells the logo endpoint to redirect to the app favicon when
+   * a ticker has no stored logo (e.g. custom tickers), so a notification ALWAYS
+   * shows a branded icon, never the OS's grey placeholder.
+   */
+  tickerIconUrl(symbol: string): string {
+    return `/api/v1/tickers/${encodeURIComponent(symbol)}/logo?fallback=app`;
+  }
 }


### PR DESCRIPTION
Add WebPushService.tickerIconUrl(...) that returns a root-relative /api/v1/tickers/.../logo?fallback=app URL and document why (fixes wrong /v1 path and Android fallback). Replace ad-hoc frontendUrl constructions in research and social services to use the new helper. Implement fallback handling in TickersController: when ?fallback=app and no logo, redirect to /favicon.svg and set no-store so push notifications show the app favicon instead of the OS grey placeholder. Update/add unit tests and mocks to cover the new helper and fallback behavior.